### PR TITLE
Refactor/db-layer

### DIFF
--- a/charts/session_dashboard_graphs.py
+++ b/charts/session_dashboard_graphs.py
@@ -1,0 +1,121 @@
+"""
+Session Dashboard Charts
+Pure functions that return Plotly figures or tabular outlier results.
+"""
+
+from __future__ import annotations
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+
+# ---------- Boxplot & outliers ----------
+
+def rpe_boxplot_per_session(df: pd.DataFrame, title: str) -> go.Figure:
+    """
+    Expects: date (datetime64), session_type, rpe
+    One box per session, x label formatted as "YYYY-MM-DD (TYPE)".
+    """
+    if df.empty:
+        return go.Figure()
+
+    xlbl = df["date"].dt.strftime("%Y-%m-%d") + " (" + df["session_type"].astype(str) + ")"
+    fig = px.box(
+        df.assign(x_label=xlbl),
+        x="x_label",
+        y="rpe",
+        color="session_type",
+        points="all",
+        labels={"x_label": "Session", "rpe": "RPE"},
+        title=title
+    )
+    fig.update_traces(boxpoints="outliers")
+    fig.update_layout(xaxis=dict(type="category"))
+    return fig
+
+
+
+def rpe_outliers_table(df: pd.DataFrame, iqr_k: float = 1.5) -> pd.DataFrame:
+    """
+    IQR-based outliers per session.
+    Returns: date, session_type, session_id, player_id, rpe, lower_fence, upper_fence
+    """
+    if df.empty:
+        return pd.DataFrame()
+
+    def _one(g: pd.DataFrame) -> pd.DataFrame:
+        q1, q3 = g["rpe"].quantile(0.25), g["rpe"].quantile(0.75)
+        iqr = q3 - q1
+        lower, upper = q1 - iqr_k * iqr, q3 + iqr_k * iqr
+        mask = (g["rpe"] < lower) | (g["rpe"] > upper)
+        out = g.loc[mask, ["date", "session_type", "session_id", "player_id", "rpe"]].copy()
+        out["lower_fence"], out["upper_fence"] = lower, upper
+        return out
+
+    return df.groupby("session_id", group_keys=False).apply(_one).reset_index(drop=True)
+
+
+# ---------- Your existing KPIs ----------
+
+def bar_avg_load_per_type(agg_df: pd.DataFrame, title: str) -> go.Figure:
+    """
+    Expects: session_type, total_load, session_count
+    """
+    if agg_df.empty:
+        return go.Figure()
+
+    df = agg_df.copy()
+    df["avg_load_per_session"] = df["total_load"] / df["session_count"]
+    type_df = df.groupby("session_type", as_index=False)["avg_load_per_session"].mean()
+
+    return px.bar(
+        type_df, x="session_type", y="avg_load_per_session",
+        title=title, color="session_type",
+        labels={"avg_load_per_session": "Avg Load / Session"}
+    )
+
+
+
+def stacked_load_per_week(agg_df: pd.DataFrame, title: str) -> go.Figure:
+    """
+    Expects: week, session_type, total_load
+    """
+    if agg_df.empty:
+        return go.Figure()
+
+    stacked_df = agg_df.pivot(index="week", columns="session_type", values="total_load").fillna(0).reset_index()
+    fig = px.bar(
+        stacked_df, x="week", y=stacked_df.columns[1:],
+        title=title, labels={"value": "Load", "week": "Week"},
+        barmode="stack"
+    )
+    return fig
+
+
+
+def stacked_pct_load_per_week(agg_df: pd.DataFrame, title: str) -> go.Figure:
+    """
+    100% stacked version of weekly load by type.
+    """
+    if agg_df.empty:
+        return go.Figure()
+
+    stacked_df = agg_df.pivot(index="week", columns="session_type", values="total_load").fillna(0)
+    stacked_df["total"] = stacked_df.sum(axis=1)
+    pct = stacked_df.div(stacked_df["total"], axis=0).drop(columns="total") * 100
+    pct = pct.reset_index().round(1)
+
+    melted = pct.melt(id_vars="week", var_name="Session Type", value_name="Percentage")
+
+    fig = px.bar(
+        melted,
+        x="week",
+        y="Percentage",
+        color="Session Type",
+        text="Percentage",
+        title=title,
+        labels={"week": "Training Week"}
+    )
+    fig.update_traces(texttemplate="%{text}%", textposition="inside")
+    fig.update_layout(barmode="stack", yaxis_title="Percentage (%)")
+    return fig

--- a/db/base.py
+++ b/db/base.py
@@ -1,0 +1,33 @@
+# db/base.py
+from typing import Any, Dict, Iterable
+from pymongo.collection import Collection
+from .errors import DatabaseError
+
+class BaseRepository:
+    def __init__(self, db, collection_name: str):
+        self.db = db
+        self.col: Collection = db[collection_name]
+
+    def find_safe(self, filt: Dict[str, Any], proj: Dict[str, int] | None = None) -> list[Dict[str, Any]]:
+        try:
+            return list(self.col.find(filt, proj))
+        except Exception as e:
+            raise DatabaseError(f"[{self.col.name}] find failed: {e}") from e
+
+    def insert_one_safe(self, doc: Dict[str, Any]):
+        try:
+            return self.col.insert_one(doc)
+        except Exception as e:
+            raise DatabaseError(f"[{self.col.name}] insert failed: {e}") from e
+
+    def update_one_safe(self, filt: Dict[str, Any], update: Dict[str, Any], upsert: bool = False):
+        try:
+            return self.col.update_one(filt, update, upsert=upsert)
+        except Exception as e:
+            raise DatabaseError(f"[{self.col.name}] update failed: {e}") from e
+
+    def bulk_write_safe(self, ops: Iterable[Any]):
+        try:
+            return self.col.bulk_write(list(ops))
+        except Exception as e:
+            raise DatabaseError(f"[{self.col.name}] bulk_write failed: {e}") from e

--- a/db/connection.py
+++ b/db/connection.py
@@ -1,0 +1,22 @@
+# db/connection.py
+from typing import Any, Dict
+from pymongo import MongoClient
+
+_client = None
+_db = None
+
+def get_db(secrets: Dict[str, Any]):
+    """Return a cached db handle built from Streamlit secrets."""
+    global _client, _db
+    if _db is not None:
+        return _db
+
+    username = secrets["mongo_username"]
+    password = secrets["mongo_password"]
+    cluster_url = secrets["mongo_cluster_url"]
+    db_name = secrets["database_name"]
+
+    uri = f"mongodb+srv://{username}:{password}@{cluster_url}/?retryWrites=true&w=majority"
+    _client = MongoClient(uri)
+    _db = _client[db_name]
+    return _db

--- a/db/errors.py
+++ b/db/errors.py
@@ -1,0 +1,6 @@
+class DatabaseError(Exception):
+    """Errors raised when MongoDB operations fail."""
+
+
+class ApplicationError(Exception):
+    """Errors raised in our own application logic (not DB-related)."""

--- a/db/mongo_wrapper.py
+++ b/db/mongo_wrapper.py
@@ -65,38 +65,56 @@ class MongoWrapper:
     # -----------------------
 
     def get_roster_df(self) -> pd.DataFrame:
-        """Return the full roster as a pandas DataFrame.
-
-        Returns:
-            DataFrame: All players with fields `_id` excluded.
-
-        Raises:
-            DatabaseError: If the query fails.
-        """
+        """Pass-through to RosterRepository.get_roster_df()."""
         try:
-            data = list(self.db.roster.find({}, {"_id": 0}))
-            return pd.DataFrame(data)
+            return self.roster_repo.get_roster_df()
+        except (DatabaseError, ApplicationError):
+            raise
         except Exception as e:
-            raise DatabaseError(f"Failed to load roster: {e}")
+            raise ApplicationError(f"mongo_wrapper.get_roster_df unexpected error: {e}") from e
+
+
+        # """Return the full roster as a pandas DataFrame.
+
+        # Returns:
+        #     DataFrame: All players with fields `_id` excluded.
+
+        # Raises:
+        #     DatabaseError: If the query fails.
+        # """
+        # try:
+        #     data = list(self.db.roster.find({}, {"_id": 0}))
+        #     return pd.DataFrame(data)
+        # except Exception as e:
+        #     raise DatabaseError(f"Failed to load roster: {e}")
         
     def save_roster_df(self, df: pd.DataFrame) -> bool:
-        """Replace the roster collection with a new DataFrame.
-
-        Args:
-            df: DataFrame with roster documents.
-
-        Returns:
-            True if the operation succeeded.
-
-        Raises:
-            DatabaseError: On MongoDB error.
-        """
+        """Pass-through to RosterRepository.save_roster_df(df)."""
         try:
-            self.db.roster.delete_many({})
-            self.db.roster.insert_many(df.to_dict("records"))
-            return True
+            return self.roster_repo.save_roster_df(df)
+        except (DatabaseError, ApplicationError):
+            raise
         except Exception as e:
-            raise DatabaseError(f"Failed to save roster: {e}")
+            raise ApplicationError(f"mongo_wrapper.save_roster_df unexpected error: {e}") from e
+
+
+        # """Replace the roster collection with a new DataFrame.
+
+        # Args:
+        #     df: DataFrame with roster documents.
+
+        # Returns:
+        #     True if the operation succeeded.
+
+        # Raises:
+        #     DatabaseError: On MongoDB error.
+        # """
+        # try:
+        #     self.db.roster.delete_many({})
+        #     self.db.roster.insert_many(df.to_dict("records"))
+        #     return True
+        # except Exception as e:
+        #     raise DatabaseError(f"Failed to save roster: {e}")
         
     def get_roster_players(self, team: str = None) -> List[Dict[str, Any]]:
         """Return all players, optionally filtered by team."""

--- a/db/mongo_wrapper.py
+++ b/db/mongo_wrapper.py
@@ -25,6 +25,9 @@ from .repositories.sessions_repo import SessionsRepository
 from .repositories.pdp_repo import PdpRepository
 from .repositories.player_pdp_repo import PlayerPdpRepository
 from .repositories.injury_repo import InjuryRepository
+from .repositories.wellness_dash_repo import WellnessDashboardRepository
+from .repositories.rpe_dashboard_repo import RpeDashboardRepository
+from .repositories.attendance_repo import AttendanceRepository
 
 
 from utils.constants import NameStyle
@@ -67,7 +70,11 @@ class MongoWrapper:
         self.sessions_repo = SessionsRepository(self.db)
         self.pdp_repo = PdpRepository(self.db)
         self.player_pdp_repo = PlayerPdpRepository(self.db)
-        self.injury_repo = InjuryRepository(self.db)    
+        self.injury_repo = InjuryRepository(self.db)
+        self.session_dashboard_repo = SessionsRepository(self.db)  # reuse sessions repo for session dashboard      
+        self.wellness_dash_repo = WellnessDashboardRepository(self.db)  # wellness dashboard repo
+        self.rpe_dash_repo = RpeDashboardRepository(self.db)  # RPE dashboard repo
+        self.attendance_repo = AttendanceRepository(self.db)  # attendance repo
 
 
 
@@ -196,463 +203,60 @@ class MongoWrapper:
 
     # Get the data for the datatable view 
     def get_wellness_matrix(self, team: str | None = None) -> pd.DataFrame:
-        """Return weekly average wellness per player in pivot form.
-
-        Args:
-            team: Optional filter ("U18" or "U21").
-
-        Returns:
-            DataFrame with player_name as rows and weeks as columns. 
-            Cell values formatted as "avg_feeling | avg_sleeping".
-
-        Raises:
-            DatabaseError: On MongoDB error.
-
-        Notes:
-            - Season start hard-coded as first Monday of August 2025.
-            - Week labels formatted as "W00", "W01", ...
-        """
         try:
-            # Load wellness entries
-            wellness_docs = list(self.db.player_wellness.find({}, {"_id": 0}))
-            wellness_df = pd.DataFrame(wellness_docs)
-            wellness_df["player_id"] = wellness_df["player_id"].astype(str)
-            wellness_df["date"] = pd.to_datetime(wellness_df["date"])
+            return self.wellness_dash_repo.get_wellness_matrix(team=team)
+        except (DatabaseError, ApplicationError):
+            raise
 
-            # Set custom season start date (first Monday of August)
-            from utils.constants import REGISTRATION_START_DATE
-            season_start = pd.to_datetime(REGISTRATION_START_DATE)
 
-            # Calculate season week number (0-based)
-            wellness_df["season_week"] = ((wellness_df["date"] - season_start).dt.days // 7).astype(int)
 
-            # Compute weekly averages
-            weekly_avg = wellness_df.groupby(["player_id", "season_week"]).agg(
-                avg_feeling=("feeling", "mean"),
-                avg_sleeping=("sleep_hours", "mean")
-            ).reset_index()
-
-            # Round and format
-            weekly_avg["combined"] = weekly_avg.apply(
-                lambda row: f"{row['avg_feeling']:.1f} | {row['avg_sleeping']:.1f}", axis=1
-            )
-
-            # Load roster
-            roster_docs = list(self.db.roster.find({}, {"_id": 0}))
-            roster_df = pd.DataFrame(roster_docs)
-            roster_df["player_id"] = roster_df["player_id"].astype(str)
-            roster_df["player_name"] = roster_df["player_last_name"] + ", " + roster_df["player_first_name"]
-
-            if team:
-                roster_df = roster_df[roster_df["team"] == team]
-
-            # Merge and pivot
-            merged = pd.merge(
-                weekly_avg,
-                roster_df[["player_id", "player_name"]],
-                on="player_id",
-                how="inner"
-            )
-
-            # Use custom week labels like "W00", "W01", ..., "W39"
-            merged["week_label"] = "W" + merged["season_week"].astype(str).str.zfill(2)
-
-            compact_df = merged.pivot(index="player_name", columns="week_label", values="combined")
-            return compact_df.reset_index()
-
-        except Exception as e:
-            raise DatabaseError(f"Failed to build compact wellness table: {e}")
-
-    
     def get_today_wellness_entries(self, team: str, target_date: date = None):
-        """Returns wellness entries for a given day (based on submission timestamp)."""
         try:
-            if target_date is None:
-                target_date = date.today()
-
-            start_ts = datetime.combine(target_date, time.min)
-            end_ts = datetime.combine(target_date, time.max)
-
-            # Use the standardized name helper; we only need player_id
-            roster = self.roster_repo.get_player_names(
-                team=team,
-                style="LAST_FIRST",
-                include_inactive=True,     # keeps parity with previous behavior
-                sort_by_name=False,        # no need to sort for backend filtering
-                fields=None
-            )
-            player_ids = [int(p["player_id"]) for p in roster if "player_id" in p]
-
-
-            # roster = self.get_roster_players(team=team)
-            # player_ids = [int(p["player_id"]) for p in roster]
-
-            return list(self.db["player_wellness"].find({
-                "player_id": {"$in": player_ids},
-                "timestamp": {"$gte": start_ts, "$lte": end_ts}
-            }))
-        
-        except Exception as e:
-            raise DatabaseError(f"Failed to fetch today's wellness entries: {e}")
+            return self.wellness_dash_repo.get_today_wellness_entries(team=team, target_date=target_date)
+        except (DatabaseError, ApplicationError):
+            raise
     
+
+
     def get_daily_wellness_overview(self, team=None) -> pd.DataFrame:
-        """Return pivot table with one row per player and one column per day showing 'feeling | sleep_hours'."""
         try:
-            wellness_data = list(self.db.player_wellness.find())
-            roster_data = list(self.db.roster.find())
-
-            if not roster_data:
-                return pd.DataFrame()
-
-            wellness_df = pd.DataFrame(wellness_data)
-            roster_df = pd.DataFrame(roster_data)
-
-            # Ensure consistent types
-            roster_df["player_id"] = roster_df["player_id"].astype(int)
-            if not wellness_df.empty:
-                wellness_df["player_id"] = wellness_df["player_id"].astype(int)
-                wellness_df["date"] = pd.to_datetime(wellness_df["date"]).dt.date
-                wellness_df["entry"] = wellness_df["feeling"].astype(str) + " | " + wellness_df["sleep_hours"].astype(str)
-
-                # Merge with player names
-                roster_df["player_name"] = roster_df["player_last_name"] + ", " + roster_df["player_first_name"]
-                merged = wellness_df.merge(roster_df[["player_id", "player_name", "team"]], on="player_id", how="left")
-
-                if team:
-                    merged = merged[merged["team"] == team]
-
-                # Pivot only available entries
-                pivot = merged.pivot_table(
-                    index="player_name",
-                    columns="date",
-                    values="entry",
-                    aggfunc="first"
-                )
-            else:
-                # No wellness entries yet
-                pivot = pd.DataFrame()
-
-            # --- Merge with full player list ---
-            roster_df["player_name"] = roster_df["player_last_name"] + ", " + roster_df["player_first_name"]
-            if team:
-                roster_df = roster_df[roster_df["team"] == team]
-
-            full_players = roster_df[["player_name"]].drop_duplicates().set_index("player_name")
-
-            # Ensure all players are shown, even if they had no entries
-            full_overview = full_players.join(pivot, how="left")
-            full_overview = full_overview.fillna("–")  # or use "" for blanks
-
-            # Final formatting
-            full_overview = full_overview.sort_index(axis=0).sort_index(axis=1)
-            full_overview.columns = full_overview.columns.astype(str)
-            full_overview.index.name = None
-
-            return full_overview
-
-        except Exception as e:
-            raise DatabaseError(f"Failed to generate wellness overview: {e}")
+            return self.wellness_dash_repo.get_daily_wellness_overview(team=team)
+        except (DatabaseError, ApplicationError):
+            raise
     
     # -------------------    
-    # RPE fetchers
+    # RPE dashboard
     # -------------------
 
     def get_rpe_loads(self, team: str | None = None) -> pd.DataFrame:
-        """Aggregate weekly RPE loads per player.
-
-        Args:
-            team: Optional team filter.
-
-        Returns:
-            DataFrame with columns: player_id, player_name, team, week, load, acute, chronic, acr.
-
-        Raises:
-            DatabaseError: On MongoDB errors.
-
-        Pipeline:
-            - Lookup sessions and roster
-            - Compute effective_minutes
-            - Compute load = RPE * minutes
-            - Group by player/week
-            - Add rolling acute:chronic ratio
-        """
         try:
-            pipeline = [
-                # Join with sessions collection
-                {"$lookup": {
-                    "from": "sessions",
-                    "localField": "session_id",
-                "foreignField": "session_id",
-                "as": "session"
-            }},
-            {"$unwind": "$session"},
-
-            # Optional team filter
-            *([{"$match": {"session.team": team}}] if team else []),
-
-            # Join with roster collection
-            {"$lookup": {
-                "from": "roster",
-                "localField": "player_id",
-                "foreignField": "player_id",
-                "as": "player"
-            }},
-            {"$unwind": "$player"},
-
-            # Add computed fields
-            {"$addFields": {
-                "player_name": {
-                    "$concat": ["$player.player_last_name", ", ", "$player.player_first_name"]
-                },
-                "week": {"$isoWeek": "$session.date"},
-                "effective_minutes": {
-                    "$cond": {
-                        "if": {"$gt": ["$training_minutes", 0]},
-                        "then": "$training_minutes",
-                        "else": "$session.duration"
-                    }
-                },
-                "load": {
-                    "$multiply": [
-                        "$rpe_score",
-                        {
-                            "$cond": {
-                                "if": {"$gt": ["$training_minutes", 0]},
-                                "then": "$training_minutes",
-                                "else": "$session.duration"
-                            }
-                        }
-                    ]
-                }
-            }},
-
-            # Group by player/week
-            {"$group": {
-                "_id": {
-                    "player_id": "$player_id",
-                    "player_name": "$player_name",
-                    "team": "$session.team",
-                    "week": "$week"
-                },
-                "load": {"$sum": "$load"}
-            }},
-
-            # Final shape
-            {"$project": {
-                "_id": 0,
-                "player_id": "$_id.player_id",
-                "player_name": "$_id.player_name",
-                "team": "$_id.team",
-                "week": "$_id.week",
-                "load": 1
-            }},
-            {"$sort": {"player_name": 1, "week": 1}}
-        ]
-            
-            df = pd.DataFrame(list(self.db.player_rpe.aggregate(pipeline)))
-
-            if df.empty:
-                return df
-
-            # Calculate rolling metrics
-            df = df.sort_values(by=["player_name", "week"])
-            df["acute"] = df.groupby("player_name")["load"].transform(lambda x: x.rolling(1, min_periods=1).mean())
-            df["chronic"] = df.groupby("player_name")["load"].transform(lambda x: x.shift().rolling(4, min_periods=1).mean())
-            df["acr"] = (df["acute"] / df["chronic"]).round(2)
-
-            return df
-        
-        except Exception as e:
-            raise DatabaseError(f"Failed to fetch RPE loads: {e}")   
+            return self.rpe_dash_repo.get_rpe_loads(team=team)
+        except (DatabaseError, ApplicationError):
+            raise
     
+
     def get_daily_rpe_overview(self, team: str | None = None) -> pd.DataFrame:
-        """
-        Returns a pivot table with one row per player (from roster),
-        one column per date, and cell text "rpe_score | training_minutes".
-        - Players with no entries are still shown.
-        - If multiple entries exist for the same player/day, the latest by timestamp wins.
-        - training_minutes defaults to the session's duration when missing/zero.
-        """
         try:
-            rpe_data = list(self.db.player_rpe.find())
-            roster_data = list(self.db.roster.find())
-            sessions_data = list(self.db.sessions.find())  # join target for default minutes
-
-            if not roster_data:
-                return pd.DataFrame()
-
-            rpe_df = pd.DataFrame(rpe_data)
-            roster_df = pd.DataFrame(roster_data)
-            sessions_df = pd.DataFrame(sessions_data)
-
-            # Ensure roster types and names
-            roster_df["player_id"] = pd.to_numeric(roster_df["player_id"], errors="coerce").astype("Int64")
-            roster_df["player_name"] = roster_df["player_last_name"] + ", " + roster_df["player_first_name"]
-
-            # Apply optional team filter on the roster side
-            if team:
-                roster_df = roster_df[roster_df["team"] == team]
-
-            # If no RPE yet, just return the player list (no date cols)
-            if rpe_df.empty:
-                return roster_df[["player_name"]].drop_duplicates().set_index("player_name")
-
-            # Normalize RPE df
-            rpe_df["player_id"] = pd.to_numeric(rpe_df["player_id"], errors="coerce").astype("Int64")
-            rpe_df["date"] = pd.to_datetime(rpe_df["date"], errors="coerce").dt.date
-            # Normalize timestamp (handles dict {"$date": ...} or strings)
-            def _to_ts(x):
-                if isinstance(x, dict) and "$date" in x:
-                    return pd.to_datetime(x["$date"], errors="coerce")
-                return pd.to_datetime(x, errors="coerce")
-            rpe_df["timestamp"] = rpe_df.get("timestamp", pd.NaT).apply(_to_ts)
-
-            # Normalize sessions df for default minutes
-            if not sessions_df.empty:
-                sessions_df = sessions_df[["session_id", "duration"]].copy()
-                sessions_df["duration"] = pd.to_numeric(sessions_df["duration"], errors="coerce").fillna(0).astype(int)
-            else:
-                sessions_df = pd.DataFrame(columns=["session_id", "duration"])
-
-            # Attach session duration to RPE
-            rpe_df = rpe_df.merge(sessions_df, on="session_id", how="left", suffixes=("", "_session"))
-
-            # training_minutes: prefer user-entered value if > 0, else session duration
-            if "training_minutes" not in rpe_df.columns:
-                rpe_df["training_minutes"] = pd.NA
-            rpe_df["training_minutes"] = pd.to_numeric(rpe_df["training_minutes"], errors="coerce")
-            rpe_df["training_minutes"] = rpe_df["training_minutes"].fillna(0)
-
-            # Effective minutes
-            rpe_df["effective_minutes"] = rpe_df.apply(
-                lambda row: int(row["training_minutes"]) if row["training_minutes"] > 0
-                else int(row["duration"]) if pd.notna(row["duration"]) and row["duration"] > 0
-                else 0,
-                axis=1
-            )
-
-            # De-duplicate by latest timestamp per (player_id, date)
-            rpe_df = rpe_df.sort_values(["player_id", "date", "timestamp"], ascending=[True, True, True])
-            rpe_latest = rpe_df.drop_duplicates(subset=["player_id", "date"], keep="last")
-
-            # Build entry string
-            rpe_latest["entry"] = rpe_latest["rpe_score"].astype(str) + " | " + rpe_latest["effective_minutes"].astype(int).astype(str)
-
-            # Keep only players from roster (right join to show players with no entries)
-            merged = rpe_latest.merge(
-                roster_df[["player_id", "player_name"]],
-                on="player_id",
-                how="right"
-            )
-
-            # Pivot
-            pivot = merged.pivot_table(
-                index="player_name",
-                columns="date",
-                values="entry",
-                aggfunc="first"
-            )
-
-            # Ensure all players appear
-            full_players = roster_df[["player_name"]].drop_duplicates().set_index("player_name")
-            full_overview = full_players.join(pivot, how="left")
-
-            # Format
-            full_overview = full_overview.fillna("–").sort_index(axis=0)
-            if full_overview.shape[1] > 0:
-                full_overview = full_overview.sort_index(axis=1)
-                full_overview.columns = full_overview.columns.astype(str)
-            full_overview.index.name = None
-
-            return full_overview
-
-        except Exception as e:
-            raise DatabaseError(f"Failed to generate RPE overview: {e}")
+            return self.rpe_dash_repo.get_daily_rpe_overview(team=team)
+        except (DatabaseError, ApplicationError):
+            raise
         
+
     def get_player_rpe_df(self) -> pd.DataFrame:
-        """Return all RPE registrations (current season stored in DB)."""
         try:
-            proj = {"_id": 0, "player_id": 1, "session_id": 1, "date": 1,
-                    "rpe_score": 1, "training_minutes": 1, "timestamp": 1}
-            return pd.DataFrame(list(self.db.player_rpe.find({}, proj)))
-        except Exception as e:
-            raise DatabaseError(f"Failed to load RPE: {e}")
+            return self.rpe_dash_repo.get_player_rpe_df()
+        except (DatabaseError, ApplicationError):
+            raise
 
     # -------------------    
     # Session dashboard
     # -------------------
     
     def get_session_rpe_aggregates(self, team=None):
-        """
-        Aggregates RPE data for the session dashboard.
-        Returns weekly total load, average player load, and per-session-type distributions.
-        """
         try:
-            pipeline = [
-                {
-                    "$lookup": {
-                        "from": "sessions",
-                        "localField": "session_id",
-                    "foreignField": "session_id",
-                    "as": "session"
-                }
-            },
-            {"$unwind": "$session"},
-        ]
-
-            if team:
-                pipeline.append({"$match": {"session.team": team}})
-
-            pipeline += [
-                {
-                    "$project": {
-                        "load": {
-                            "$multiply": [
-                                "$rpe_score",
-                                {
-                                    "$cond": {
-                                        "if": {"$gt": ["$training_minutes", 0]},
-                                        "then": "$training_minutes",
-                                        "else": "$session.duration"
-                                    }
-                                }
-                            ]
-                        },
-                        "weeknumber": "$session.weeknumber",
-                        "session_type": "$session.session_type",
-                        "session_id": "$session.session_id",
-                        "player_id": 1,
-                        "team": "$session.team"
-                    }
-                },
-                {
-                    "$group": {
-                        "_id": {
-                            "week": "$weeknumber",
-                            "session_type": "$session_type"
-                        },
-                        "total_load": {"$sum": "$load"},
-                        "sessions": {"$addToSet": "$session_id"},
-                        "players": {"$addToSet": "$player_id"}
-                    }
-                },
-                {
-                    "$project": {
-                        "week": "$_id.week",
-                        "session_type": "$_id.session_type",
-                        "total_load": 1,
-                        "session_count": {"$size": "$sessions"},
-                        "player_count": {"$size": "$players"},
-                        "_id": 0
-                    }
-                },
-                {"$sort": {"week": 1, "session_type": 1}}
-            ]
-
-            return list(self.db["player_rpe"].aggregate(pipeline))
-        
-        except Exception as e:
-            raise DatabaseError(f"Failed to fetch session RPE aggregates: {e}")
+            return self.rpe_dash_repo.get_session_rpe_aggregates(team=team)
+        except (DatabaseError, ApplicationError):
+            raise
             
     # ---------------------
     # Player PDP functions
@@ -666,14 +270,7 @@ class MongoWrapper:
         except Exception as e:
             raise ApplicationError(f"mongo_wrapper.get_latest_pdp_for_player unexpected error: {e}") from e
 
-        # """Get the most recent PDP for a given player."""
-        # try:
-        #     return self.db["player_pdp"].find_one(
-        #         {"player_id": player_id},
-        #         sort=[("last_updated", -1)]
-        #     )
-        # except Exception as e:
-        #     raise DatabaseError(f"Failed to fetch latest PDP for player {player_id}: {e}")
+
 
     def insert_new_pdp(self, pdp_data: dict):
         try:
@@ -683,11 +280,7 @@ class MongoWrapper:
         except Exception as e:
             raise ApplicationError(f"mongo_wrapper.insert_new_pdp unexpected error: {e}") from e
 
-        # """Insert a new PDP document into the collection."""
-        # try:
-        #     return self.db["player_pdp"].insert_one(pdp_data).inserted_id
-        # except Exception as e:
-        #     raise DatabaseError(f"Failed to insert new PDP: {e}")
+
 
     def get_all_pdps_for_player(self, player_id: int):
         try:
@@ -697,14 +290,6 @@ class MongoWrapper:
         except Exception as e:
             raise ApplicationError(f"mongo_wrapper.get_all_pdps_for_player unexpected error: {e}") from e
 
-
-        #"""Returns all PDP documents for a given player_id, sorted by creation time (descending)."""
-        # try:
-        #     collection = self.db["player_pdp"]
-        #     results = list(collection.find({"player_id": player_id}))
-        #     return results
-        # except Exception as e:
-        #     raise DatabaseError(f"Failed to fetch all PDPs for player {player_id}: {e}")
 
     # -----------------------------
     # Session attendance functions
@@ -726,51 +311,13 @@ class MongoWrapper:
             session_type: Filter by a single type (e.g., "M") or by multiple types (e.g., ["T1","T2","T3","T4"]).
         """
         try:
-            q: Dict[str, Any] = {"team": team}
-            if up_to_date:
-                end = datetime.combine(up_to_date, time.max)
-                q["date"] = {"$lte": end}
+            return self.attendance_repo.get_recent_sessions(
+                team=team, limit=limit, up_to_date=up_to_date, session_type=session_type
+            )
+        except (DatabaseError, ApplicationError):
+            raise
 
-            if session_type:
-                if isinstance(session_type, list):
-                    q["session_type"] = {"$in": session_type}
-                else:
-                    q["session_type"] = session_type
 
-            cur = self.db["sessions"].find(q, {"_id": 0}).sort([("date", -1)])
-
-            # Apply limit only when requested
-            if isinstance(limit, int) and limit > 0:
-                cur = cur.limit(limit * 2)  # extra to tolerate client-side date dedup
-
-            records = list(cur)
-
-            # Stable sort (handles datetime/date/ISO strings)
-            def _key(s):
-                d = s.get("date")
-                if isinstance(d, datetime):
-                    return d
-                if isinstance(d, date):
-                    return datetime.combine(d, time.min)
-                try:
-                    return datetime.fromisoformat(str(d))
-                except Exception:
-                    return datetime.min
-
-            records.sort(key=_key, reverse=True)
-
-            if isinstance(limit, int) and limit > 0:
-                return records[: (limit * 2)]
-            return records
-        except Exception as e:
-            raise DatabaseError(f"Failed to fetch recent sessions: {e}") from e
-
-    # def get_roster_players(self, team: str) -> List[Dict[str, Any]]:
-    #     """Return all players for a team from `roster`."""
-    #     try:
-    #         return list(self.db["roster"].find({"team": team}, {"_id": 0}))
-    #     except Exception as e:
-    #         raise DatabaseError(f"Failed to fetch roster: {e}") from e
 
     def upsert_attendance_full(
         self,
@@ -780,83 +327,19 @@ class MongoWrapper:
         absent_items: List[Dict[str, Any]],
         user: str,
     ) -> None:
-        """Insert or update full attendance (present + absent) for a session.
-
-        Args:
-            session_id: Session identifier (e.g., "20250901U21").
-            team: "U18" | "U21".
-            present_ids: Player IDs marked present (deduped + sorted in this method).
-            absent_items: List of {"player_id": int, "reason": str} where `reason` is an ID
-                from the canonical set (e.g., "injury", "individual", "physio_internal",
-                "physio_external", "school", "holiday", "illness", "awol", "other_team").
-            user: Display name or identifier of the editor.
-
-        Notes:
-            - Overwrites both `present` and `absent` arrays atomically.
-            - Validates/normalizes absence reasons against the canonical set.
-            (Spaces → underscores, case-insensitive; e.g., "Other team" -> "other_team")
-            - Temporarily allows deprecated legacy ID "excused" for backward compatibility.
-        """
-        # Prefer to derive valid IDs from the single source of truth in `constants`.
         try:
-            from utils.constants import ABSENCE_REASONS as ABSENCE_META  # [{"id","label","icon"}, ...]
-            VALID_IDS: Set[str] = {r["id"] for r in ABSENCE_META}
-        except Exception:
-            # Fallback if constants cannot be imported (tests, tooling, etc.)
-            VALID_IDS = {
-                "injury",
-                "individual",
-                "physio_internal",
-                "physio_external",
-                "school",
-                "holiday",
-                "illness",
-                "awol",
-                "other_team",
-            }
-
-        # Optional: keep legacy IDs allowed for now to avoid breaking old callers.
-        DEPRECATED_IDS: Set[str] = {"excused"}  # consider migrating or removing later
-
-        def _norm_reason(reason: str) -> str:
-            """Normalize a human-entered/old value to an ID-like form."""
-            r = str(reason).strip().lower().replace(" ", "_")
-            return r
-
-        try:
-            # Clean & dedupe present IDs
-            present_clean = sorted(set(int(pid) for pid in present_ids))
-
-            # Validate/normalize absentees
-            absent_clean = []
-            for item in absent_items:
-                pid = int(item["player_id"])
-                norm = _norm_reason(item["reason"])
-                if norm not in VALID_IDS and norm not in DEPRECATED_IDS:
-                    raise ValueError(f"Invalid absence reason '{item['reason']}' (normalized '{norm}') for player_id {pid}")
-                absent_clean.append({"player_id": pid, "reason": norm})
-
-            now = datetime.utcnow()
-            self.db["attendance"].update_one(
-                {"session_id": session_id},
-                {
-                    "$setOnInsert": {
-                        "session_id": session_id,
-                        "team": team,
-                        "created": now,
-                    },
-                    "$set": {
-                        "present": present_clean,
-                        "absent": absent_clean,
-                        "last_updated": now,
-                        "user": user,
-                    },
-                },
-                upsert=True,
+            return self.attendance_repo.upsert_attendance_full(
+                session_id=session_id,
+                team=team,
+                present_ids=present_ids,
+                absent_items=absent_items,
+                user=user,
             )
-        except Exception as e:
-            raise DatabaseError(f"Failed to upsert attendance: {e}") from e
+        except (DatabaseError, ApplicationError):
+            raise
         
+
+
     def save_match_minutes_once(
         self,
         session_id: str,
@@ -864,38 +347,16 @@ class MongoWrapper:
         minutes_items: List[Dict[str, Any]],
         user: str,
     ) -> None:
-        """Create match minutes for a session exactly once.
-
-        - Inserts a new document for session_id; raises if it already exists.
-        - Normalizes minutes to int and clamps to [0, 120].
-        """
         try:
-            existing = self.db["match_minutes"].find_one({"session_id": session_id}, {"_id": 1})
-            if existing:
-                raise DatabaseError("Match minutes already saved for this session (immutable by design).")
-
-            cleaned = []
-            for item in minutes_items:
-                pid = int(item["player_id"])
-                mins = max(0, min(120, int(item.get("minutes", 0))))
-                cleaned.append({"player_id": pid, "minutes": mins})
-
-            now = datetime.utcnow()
-            doc = {
-                "session_id": session_id,
-                "team": team,
-                "minutes": cleaned,
-                "created": now,
-                "last_updated": now,
-                "user": user,
-            }
-            self.db["match_minutes"].insert_one(doc)
-        except DatabaseError:
+            return self.attendance_repo.save_match_minutes_once(
+                session_id=session_id, team=team, minutes_items=minutes_items, user=user
+            )
+        except (DatabaseError, ApplicationError):
             raise
-        except Exception as e:
-            raise DatabaseError(f"Failed to save match minutes: {e}") from e
     
-    # --- Injury functions ------------------------------------------------------------
+    # -----------------------------
+    # Injury management functions
+    # -----------------------------
 
     def insert_player_injury(self, injury_doc: dict) -> str:
         try:
@@ -903,17 +364,23 @@ class MongoWrapper:
         except (DatabaseError, ApplicationError):
             raise
 
+
+
     def get_player_injuries(self, player_id: int, sort_desc: bool = True) -> list:
         try:
             return self.injury_repo.get_player_injuries(player_id=int(player_id), sort_desc=sort_desc)
         except (DatabaseError, ApplicationError):
             raise
 
+
+
     def get_injury_by_id(self, injury_id: str):
         try:
             return self.injury_repo.get_injury_by_id(injury_id=injury_id)
         except (DatabaseError, ApplicationError):
             raise
+
+
 
     def add_treatment_session(self, injury_id: str, treatment_session: dict, current_status: str, updated_by: str) -> bool:
         try:

--- a/db/mongo_wrapper.py
+++ b/db/mongo_wrapper.py
@@ -324,8 +324,19 @@ class MongoWrapper:
             start_ts = datetime.combine(target_date, time.min)
             end_ts = datetime.combine(target_date, time.max)
 
-            roster = self.get_roster_players(team=team)
-            player_ids = [int(p["player_id"]) for p in roster]
+            # Use the standardized name helper; we only need player_id
+            roster = self.roster_repo.get_player_names(
+                team=team,
+                style="LAST_FIRST",
+                include_inactive=True,     # keeps parity with previous behavior
+                sort_by_name=False,        # no need to sort for backend filtering
+                fields=None
+            )
+            player_ids = [int(p["player_id"]) for p in roster if "player_id" in p]
+
+
+            # roster = self.get_roster_players(team=team)
+            # player_ids = [int(p["player_id"]) for p in roster]
 
             return list(self.db["player_wellness"].find({
                 "player_id": {"$in": player_ids},

--- a/db/mongo_wrapper.py
+++ b/db/mongo_wrapper.py
@@ -116,13 +116,13 @@ class MongoWrapper:
         # except Exception as e:
         #     raise DatabaseError(f"Failed to save roster: {e}")
         
-    def get_roster_players(self, team: str = None) -> List[Dict[str, Any]]:
-        """Return all players, optionally filtered by team."""
-        try:
-            query = {"team": team} if team else {}
-            return list(self.db["roster"].find(query))
-        except Exception as e:
-            raise DatabaseError(f"Failed to fetch roster players: {e}")
+    # def get_roster_players(self, team: str = None) -> List[Dict[str, Any]]:
+    #     """Return all players, optionally filtered by team."""
+    #     try:
+    #         query = {"team": team} if team else {}
+    #         return list(self.db["roster"].find(query))
+    #     except Exception as e:
+    #         raise DatabaseError(f"Failed to fetch roster players: {e}")
 
     def get_player_names(
         self,

--- a/db/repositories/attendance_repo.py
+++ b/db/repositories/attendance_repo.py
@@ -1,0 +1,214 @@
+# db/repositories/attendance_repo.py
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from typing import Any, Dict, List, Optional, Set, Union
+
+from pymongo.errors import PyMongoError
+
+from ..base import BaseRepository
+from ..errors import DatabaseError, ApplicationError
+
+
+class AttendanceRepository(BaseRepository):
+    """
+    Repository for:
+      - listing recent sessions
+      - upserting session attendance
+      - saving per-match minutes (write-once)
+    Collections used: 'sessions', 'attendance', 'match_minutes'
+    """
+
+    def __init__(self, db):
+        super().__init__(db, "attendance")   # default col for BaseRepository methods
+        self.sessions = db["sessions"]
+        self.minutes = db["match_minutes"]
+
+    # ---------------- Recent sessions ----------------
+    def get_recent_sessions(
+        self,
+        *,
+        team: str,
+        limit: Optional[int] = 6,
+        up_to_date: Optional[date] = None,
+        session_type: Union[str, List[str], None] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return recent sessions for a team (date DESC).
+
+        Args:
+            team: "U18" | "U21".
+            limit: Max number of sessions to fetch. If None or <=0, no limit is applied.
+            up_to_date: Include sessions on or before this date.
+            session_type: Filter by a single type (e.g., "M") or by multiple types (e.g., ["T1","T2","T3","T4"]).
+        """
+        if not team:
+            raise ApplicationError("get_recent_sessions: 'team' is required.")
+
+        try:
+            q: Dict[str, Any] = {"team": team}
+            if up_to_date:
+                end = datetime.combine(up_to_date, time.max)
+                q["date"] = {"$lte": end}
+
+            if session_type:
+                if isinstance(session_type, list):
+                    q["session_type"] = {"$in": session_type}
+                else:
+                    q["session_type"] = session_type
+
+            cur = self.sessions.find(q, {"_id": 0}).sort([("date", -1)])
+
+            # Apply limit, with a small buffer as in original code
+            if isinstance(limit, int) and limit > 0:
+                cur = cur.limit(limit * 2)
+
+            records = list(cur)
+
+            # Stable sort that copes with date/datetime/iso
+            def _key(s):
+                d = s.get("date")
+                if isinstance(d, datetime):
+                    return d
+                if isinstance(d, date):
+                    return datetime.combine(d, time.min)
+                try:
+                    return datetime.fromisoformat(str(d))
+                except Exception:
+                    return datetime.min
+
+            records.sort(key=_key, reverse=True)
+
+            if isinstance(limit, int) and limit > 0:
+                return records[: (limit * 2)]
+            return records
+
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to fetch recent sessions: {e}") from e
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_recent_sessions: {e}") from e
+
+    # ---------------- Upsert attendance (present + absent) ----------------
+    def upsert_attendance_full(
+        self,
+        *,
+        session_id: str,
+        team: str,
+        present_ids: List[int],
+        absent_items: List[Dict[str, Any]],
+        user: str,
+    ) -> None:
+        """Insert or update full attendance (present + absent) for a session.
+
+        Args:
+            session_id: Session identifier (e.g., "20250901U21").
+            team: "U18" | "U21".
+            present_ids: Player IDs marked present (deduped + sorted in this method).
+            absent_items: List of {"player_id": int, "reason": str} where `reason` is an ID
+                from the canonical set (e.g., "injury", "individual", "physio_internal",
+                "physio_external", "school", "holiday", "illness", "awol", "other_team").
+            user: Display name or identifier of the editor.
+
+        Notes:
+            - Overwrites both `present` and `absent` arrays atomically.
+            - Validates/normalizes absence reasons against the canonical set.
+            (Spaces → underscores, case-insensitive; e.g., "Other team" -> "other_team")
+            - Temporarily allows deprecated legacy ID "excused" for backward compatibility.
+        """
+        if not session_id or not team:
+            raise ApplicationError("upsert_attendance_full: 'session_id' and 'team' are required.")
+        if user is None or str(user).strip() == "":
+            raise ApplicationError("upsert_attendance_full: 'user' is required.")
+
+        # Try to import canonical absence reasons from utils; fall back to a static set.
+        try:
+            from utils.constants import ABSENCE_REASONS as ABSENCE_META  # [{"id","label","emoji"}, ...]
+            VALID_IDS: Set[str] = {str(r["id"]) for r in ABSENCE_META}
+        except Exception:
+            VALID_IDS = {
+                "injury", "individual", "physio_internal", "physio_external",
+                "school", "holiday", "illness", "awol", "other_team",
+            }
+        DEPRECATED_IDS: Set[str] = {"excused"}  # temporary compatibility
+
+        def _norm_reason(reason: str) -> str:
+            return str(reason).strip().lower().replace(" ", "_")
+
+        try:
+            # Clean & dedupe present IDs
+            present_clean = sorted(set(int(pid) for pid in present_ids))
+
+            # Validate & normalize absentees
+            absent_clean: List[Dict[str, Any]] = []
+            for item in absent_items:
+                pid = int(item["player_id"])
+                norm = _norm_reason(item["reason"])
+                if norm not in VALID_IDS and norm not in DEPRECATED_IDS:
+                    raise ApplicationError(
+                        f"Invalid absence reason '{item['reason']}' (normalized '{norm}') for player_id {pid}"
+                    )
+                absent_clean.append({"player_id": pid, "reason": norm})
+
+            now = datetime.utcnow()
+            # Use BaseRepository's default collection ('attendance') via self.col
+            self.col.update_one(
+                {"session_id": session_id},
+                {
+                    "$setOnInsert": {
+                        "session_id": session_id,
+                        "team": team,
+                        "created": now,
+                    },
+                    "$set": {
+                        "present": present_clean,
+                        "absent": absent_clean,
+                        "last_updated": now,
+                        "user": user,
+                    },
+                },
+                upsert=True,
+            )
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to upsert attendance: {e}") from e
+
+    # ---------------- Save match minutes (write-once) ----------------
+    def save_match_minutes_once(
+        self,
+        *,
+        session_id: str,
+        team: str,
+        minutes_items: List[Dict[str, Any]],
+        user: str,
+    ) -> None:
+        """Create match minutes for a session exactly once.
+
+        - Inserts a new document for session_id; raises if it already exists.
+        - Normalizes minutes to int and clamps to [0, 120].
+        """
+        if not session_id or not team:
+            raise ApplicationError("save_match_minutes_once: 'session_id' and 'team' are required.")
+        if user is None or str(user).strip() == "":
+            raise ApplicationError("save_match_minutes_once: 'user' is required.")
+
+        try:
+            existing = self.minutes.find_one({"session_id": session_id}, {"_id": 1})
+            if existing:
+                raise DatabaseError("Match minutes already saved for this session (immutable by design).")
+
+            cleaned: List[Dict[str, int]] = []
+            for item in minutes_items:
+                pid = int(item["player_id"])
+                mins = max(0, min(120, int(item.get("minutes", 0))))
+                cleaned.append({"player_id": pid, "minutes": mins})
+
+            now = datetime.utcnow()
+            doc = {
+                "session_id": session_id,
+                "team": team,
+                "minutes": cleaned,
+                "created": now,
+                "last_updated": now,
+                "user": user,
+            }
+            self.minutes.insert_one(doc)
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to save match minutes: {e}") from e

--- a/db/repositories/injury_repo.py
+++ b/db/repositories/injury_repo.py
@@ -1,24 +1,61 @@
 from __future__ import annotations
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+from datetime import datetime, date
+
+from bson import ObjectId
 from pymongo.database import Database
 from pymongo.errors import PyMongoError
 
 from db.errors import DatabaseError, ApplicationError
 
+# You can keep this alias for backwards-compat logs if you want
 class InjuryRepoError(Exception):
     pass
 
-class InjuryRepo:
+
+def _as_oid(maybe_id: str) -> Optional[ObjectId]:
+    try:
+        return ObjectId(maybe_id)
+    except Exception:
+        return None
+
+
+def _as_datetime(d: Any) -> datetime:
+    """Accept datetime|date|iso-string -> naive UTC datetime (ok for Mongo)."""
+    if isinstance(d, datetime):
+        return d
+    if isinstance(d, date):
+        return datetime(d.year, d.month, d.day)
+    if isinstance(d, str):
+        # try simple ISO parse; tolerate trailing 'Z'
+        try:
+            return datetime.fromisoformat(d.replace("Z", "+00:00")).replace(tzinfo=None)
+        except Exception:
+            pass
+    raise ApplicationError(f"Invalid date/datetime value: {d!r}")
+
+
+class InjuryRepository:
+    """Repository for player injuries (collection: 'player_injuries')."""
+
     def __init__(self, db: Database, collection: str = "player_injuries") -> None:
         self.col = db[collection]
 
+    # -------------------- READ (existing) --------------------
     def list_injuries_by_team(self, team: str) -> List[Dict[str, Any]]:
         try:
             docs = list(self.col.find({"team": team}))
-            docs.sort(key=lambda d: (str(d.get("updated_at") or ""), str(d.get("injury_date") or "")), reverse=True)
+            # Sort by updated_at (fallback: injury_date) DESC
+            docs.sort(
+                key=lambda d: (
+                    str(d.get("updated_at") or ""),
+                    str(d.get("injury_date") or ""),
+                ),
+                reverse=True,
+            )
             return docs
         except PyMongoError as e:
-            raise InjuryRepoError(f"Failed to fetch team injuries: {e}")
+            raise DatabaseError(f"Failed to fetch team injuries: {e}") from e
 
     @staticmethod
     def latest_status(injury: Dict[str, Any]) -> str:
@@ -32,3 +69,125 @@ class InjuryRepo:
         except Exception:
             pass
         return sessions[0].get("status_after", "—")
+
+    # -------------------- CREATE --------------------
+    def insert_player_injury(self, *, injury_doc: Dict[str, Any]) -> str:
+        """Insert a new injury and return inserted _id (as str)."""
+        if not isinstance(injury_doc, dict):
+            raise ApplicationError("insert_player_injury: 'injury_doc' must be a dict.")
+
+        doc = dict(injury_doc)
+        now = datetime.utcnow()
+        doc.setdefault("created_at", now)
+        doc.setdefault("updated_at", now)
+        doc.setdefault("last_updated", now)          # if you use this elsewhere
+        doc.setdefault("current_status", "open")
+        doc.setdefault("treatment_sessions", [])     # embedded sessions array
+        doc.setdefault("comments", [])               # optional free comments stream
+
+        # Normalize optional injury_date if present
+        if "injury_date" in doc:
+            doc["injury_date"] = _as_datetime(doc["injury_date"])
+
+        try:
+            res = self.col.insert_one(doc)
+            return str(res.inserted_id)
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to insert injury: {e}") from e
+
+    # -------------------- READ: player history --------------------
+    def get_player_injuries(self, *, player_id: int, sort_desc: bool = True) -> List[Dict[str, Any]]:
+        """All injuries for a player, sorted by created_at."""
+        sort_order = -1 if sort_desc else 1
+        try:
+            return list(self.col.find({"player_id": int(player_id)}).sort("created_at", sort_order))
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to load injuries for player {player_id}: {e}") from e
+
+    # -------------------- READ: by id --------------------
+    def get_injury_by_id(self, *, injury_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch by Mongo _id (hex) or by custom injury_id string field."""
+        filt: Dict[str, Any]
+        oid = _as_oid(injury_id)
+        filt = {"_id": oid} if oid else {"injury_id": injury_id}
+        try:
+            return self.col.find_one(filt)
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to fetch injury: {e}") from e
+
+    # -------------------- UPDATE: add embedded treatment session --------------------
+    def add_treatment_session(
+        self,
+        *,
+        injury_id: str,
+        treatment_session: Dict[str, Any],
+        current_status: str,
+        updated_by: str,
+    ) -> bool:
+        """Append a treatment session and update current_status/audit fields."""
+        if not isinstance(treatment_session, dict):
+            raise ApplicationError("add_treatment_session: 'treatment_session' must be a dict.")
+        if not current_status:
+            raise ApplicationError("add_treatment_session: 'current_status' is required.")
+        if not updated_by:
+            raise ApplicationError("add_treatment_session: 'updated_by' is required.")
+
+        ts = dict(treatment_session)
+        # normalize & enforce required fields
+        if "session_date" not in ts:
+            raise ApplicationError("add_treatment_session: missing 'session_date'.")
+        ts["session_date"] = _as_datetime(ts["session_date"])
+        ts["created_at"] = ts.get("created_at") or datetime.utcnow()
+        if not ts.get("created_by"):
+            raise ApplicationError("add_treatment_session: missing 'created_by'.")
+        # default status_after if not provided
+        ts.setdefault("status_after", current_status)
+        # normalize comment
+        if "comment" in ts and isinstance(ts["comment"], str):
+            ts["comment"] = ts["comment"].strip()
+
+        # filter (by _id or injury_id)
+        oid = _as_oid(injury_id)
+        filt = {"_id": oid} if oid else {"injury_id": injury_id}
+
+        update = {
+            "$push": {"treatment_sessions": ts},
+            "$set": {
+                "current_status": current_status,
+                "updated_by": updated_by,
+                "updated_at": datetime.utcnow(),
+                "last_updated": datetime.utcnow(),
+            },
+        }
+
+        try:
+            res = self.col.update_one(filt, update)
+            if res.matched_count == 0:
+                raise DatabaseError("Injury not found.")
+            return res.modified_count > 0
+        except PyMongoError as e:
+            raise DatabaseError(f"Could not add treatment session: {e}") from e
+
+    # -------------------- UPDATE: optional free comment stream --------------------
+    def add_injury_comment(self, *, injury_id: str, text: str, author_email: str) -> bool:
+        """Append a free-form comment in 'comments' (separate from treatment_sessions)."""
+        if not text or not text.strip():
+            raise ApplicationError("add_injury_comment: 'text' is required.")
+        if not author_email:
+            raise ApplicationError("add_injury_comment: 'author_email' is required.")
+
+        comment = {"ts": datetime.utcnow(), "author": author_email, "text": text.strip()}
+
+        oid = _as_oid(injury_id)
+        filt = {"_id": oid} if oid else {"injury_id": injury_id}
+
+        try:
+            res = self.col.update_one(
+                filt,
+                {"$push": {"comments": comment}, "$set": {"last_updated": datetime.utcnow(), "updated_at": datetime.utcnow()}},
+            )
+            if res.matched_count == 0:
+                raise DatabaseError("Injury not found.")
+            return res.modified_count > 0
+        except PyMongoError as e:
+            raise DatabaseError(f"Could not add comment: {e}") from e

--- a/db/repositories/pdp_repo.py
+++ b/db/repositories/pdp_repo.py
@@ -1,0 +1,77 @@
+# db/repositories/pdp_repo.py
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+
+from ..base import BaseRepository
+from ..errors import DatabaseError, ApplicationError
+
+
+class PdpRepository(BaseRepository):
+    """
+    Repository for team PDP structures.
+    Collection: `pdp_structure`
+    Documents are keyed by `_id = "<TEAM>_structure"`.
+    """
+
+    def __init__(self, db):
+        super().__init__(db, "pdp_structure")
+
+
+
+    def get_pdp_structure_for_team(self, *, team: str) -> Optional[Dict[str, Any]]:
+        """Fetch the PDP structure for a given team.
+
+        Args:
+            team: Team code (e.g. "U21").
+
+        Returns:
+            The PDP structure document without any changes, or None if not found.
+
+        Raises:
+            DatabaseError: On MongoDB error.
+            ApplicationError: If team is empty.
+        """
+        if not team:
+            raise ApplicationError("get_pdp_structure_for_team: 'team' is required.")
+        try:
+            return self.col.find_one({"_id": f"{team}_structure"})
+        except Exception as e:
+            raise DatabaseError(f"Failed to load PDP structure for {team}: {e}") from e
+        
+
+
+    def update_pdp_structure_for_team(self, *, team: str, updated_doc: Dict[str, Any]) -> bool:
+        """Insert or replace the PDP structure for a team (upsert).
+
+        Args:
+            team: Team code.
+            updated_doc: PDP structure document (will be stored verbatim).
+
+        Returns:
+            True if a document was upserted or modified.
+
+        Raises:
+            DatabaseError: On MongoDB error.
+            ApplicationError: If inputs are invalid.
+        """
+        if not team:
+            raise ApplicationError("update_pdp_structure_for_team: 'team' is required.")
+        if not isinstance(updated_doc, dict):
+            raise ApplicationError("update_pdp_structure_for_team: 'updated_doc' must be a dict.")
+
+        try:
+            updated_doc = dict(updated_doc)  # shallow copy
+            updated_doc["_id"] = f"{team}_structure"
+            result = self.col.replace_one({"_id": updated_doc["_id"]}, updated_doc, upsert=True)
+            return (result.modified_count or 0) > 0 or (result.upserted_id is not None)
+        except Exception as e:
+            raise DatabaseError(f"Failed to update PDP structure for {team}: {e}") from e
+        
+        
+
+    def list_all_team_structures(self) -> List[str]:
+        """List all team-specific PDP structure IDs (e.g., 'U21_structure')."""
+        try:
+            return [doc["_id"] for doc in self.col.find({}, {"_id": 1})]
+        except Exception as e:
+            raise DatabaseError(f"Failed to list PDP structures: {e}") from e

--- a/db/repositories/player_pdp_repo.py
+++ b/db/repositories/player_pdp_repo.py
@@ -1,0 +1,83 @@
+# db/repositories/player_pdp_repo.py
+from __future__ import annotations
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from ..base import BaseRepository
+from ..errors import DatabaseError, ApplicationError
+
+
+class PlayerPdpRepository(BaseRepository):
+    """
+    Repository for player PDP documents.
+    Collection: 'player_pdp'
+    Recommended fields:
+      - player_id: int
+      - team: str (optional but useful)
+      - created_at: datetime
+      - last_updated: datetime
+      - author: str (who created/updated)
+      - status: str (e.g., 'draft' | 'final')
+      - payload: dict (the PDP content)
+    """
+
+    def __init__(self, db):
+        super().__init__(db, "player_pdp")
+
+
+
+    # ---- Read ----
+    def get_latest_pdp_for_player(self, *, player_id: int) -> Optional[Dict[str, Any]]:
+        """Return the most recent PDP for a player (by last_updated desc)."""
+        if player_id is None:
+            raise ApplicationError("get_latest_pdp_for_player: 'player_id' is required.")
+        try:
+            return self.col.find_one({"player_id": int(player_id)}, sort=[("last_updated", -1)])
+        except Exception as e:
+            raise DatabaseError(f"Failed to fetch latest PDP for player {player_id}: {e}") from e
+        
+
+
+    def get_all_pdps_for_player(self, *, player_id: int) -> List[Dict[str, Any]]:
+        """Return all PDPs for a player, sorted by last_updated desc."""
+        if player_id is None:
+            raise ApplicationError("get_all_pdps_for_player: 'player_id' is required.")
+        try:
+            docs = list(self.col.find({"player_id": int(player_id)}).sort("last_updated", -1))
+            return docs
+        except Exception as e:
+            raise DatabaseError(f"Failed to fetch all PDPs for player {player_id}: {e}") from e
+        
+        
+
+    # ---- Write ----
+    def insert_new_pdp(self, *, pdp_data: Dict[str, Any]) -> Any:
+        """Insert a new PDP document. Fills timestamps if missing.
+
+        Returns:
+            The inserted _id
+
+        Raises:
+            ApplicationError: if required fields are missing/invalid.
+            DatabaseError: on Mongo failure.
+        """
+        if not isinstance(pdp_data, dict):
+            raise ApplicationError("insert_new_pdp: 'pdp_data' must be a dict.")
+
+        # Minimal required fields
+        required = ["player_id", "payload"]
+        missing = [k for k in required if k not in pdp_data]
+        if missing:
+            raise ApplicationError(f"insert_new_pdp: missing fields: {', '.join(missing)}")
+
+        doc = dict(pdp_data)
+        # normalize/ensure timestamps
+        now = datetime.utcnow()
+        doc.setdefault("created_at", now)
+        doc.setdefault("last_updated", now)
+
+        try:
+            res = self.col.insert_one(doc)
+            return res.inserted_id
+        except Exception as e:
+            raise DatabaseError(f"Failed to insert new PDP: {e}") from e

--- a/db/repositories/roster_repo.py
+++ b/db/repositories/roster_repo.py
@@ -1,0 +1,101 @@
+# db/repositories/roster_repo.py
+from typing import Any, Dict, List, Optional
+from ..base import BaseRepository
+from ..errors import DatabaseError, ApplicationError
+
+from utils.constants import NameStyle
+
+class RosterRepository(BaseRepository):
+    def __init__(self, db):
+        super().__init__(db, "roster")
+
+    def _format_player_name(
+        self,
+        doc: Dict[str, Any],
+        style: NameStyle = "LAST_FIRST",
+    ) -> str:
+        """Format a roster doc into a display name.
+
+        Styles:
+            - "LAST_FIRST" (default): "DOE, John"
+            - "First Last": "John Doe"
+            - "LAST FirstInitial.": "DOE J."
+        """
+        first = str(doc.get("player_first_name") or doc.get("first_name") or "").strip()
+        last  = str(doc.get("player_last_name")  or doc.get("last_name")  or "").strip()
+
+        if style == "First Last":
+            return " ".join(p for p in [first, last] if p)
+        if style == "LAST FirstInitial.":
+            fi = f"{first[:1].upper()}." if first else ""
+            return " ".join(p for p in [last.upper(), fi] if p).strip()
+        # default: LAST, First
+        return ", ".join([last.upper(), first]).strip(", ").replace(" ,", ",")
+
+    def get_player_names(
+        self,
+        team: str,
+        style: NameStyle = "LAST_FIRST",
+        include_inactive: bool = False,
+        sort_by_name: bool = True,
+        fields: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return players with normalized ids and display names.
+
+        Args:
+            team: "U18" | "U21".
+            style: Display style for names.
+            include_inactive: If your roster has an `active` flag, include inactive too.
+            sort_by_name: Sort by the rendered display name.
+            fields: Extra fields to include from roster.
+
+        Returns:
+            [{"player_id": int, "display_name": str, ...}, ...]
+
+        Raises:
+            DatabaseError: If the underlying MongoDB query fails.
+            ApplicationError: If roster data is malformed (e.g., invalid `player_id`).
+        """
+        try:
+            q: Dict[str, Any] = {"team": team}
+            if not include_inactive:
+                q.update({"$or": [{"active": True}, {"active": {"$exists": False}}]})
+
+            projection = {
+                "_id": 0, "player_id": 1,
+                "player_first_name": 1, "player_last_name": 1,
+                "first_name": 1, "last_name": 1,
+            }
+            if fields:
+                for f in fields:
+                    projection[f] = 1
+
+            docs = list(self.find_safe(q, projection))
+
+            out: List[Dict[str, Any]] = []
+            for d in docs:
+                try:
+                    pid = int(d.get("player_id"))
+                except Exception:
+                    continue
+                display_name = self._format_player_name(d, style=style)
+                item = {"player_id": pid, "display_name": display_name}
+                if fields:
+                    for f in fields:
+                        if f in d:
+                            item[f] = d[f]
+                out.append(item)
+
+            if sort_by_name:
+                out.sort(key=lambda x: (x["display_name"], x["player_id"]))
+            return out
+        
+        except DatabaseError:
+            # re-raise DB errors unchanged
+            raise
+        except ApplicationError:
+            # re-raise app errors unchanged
+            raise
+        except Exception as e:
+            # catch-all safety net
+            raise ApplicationError(f"Unexpected error in get_player_names: {e}") from e

--- a/db/repositories/rpe_dashboard_repo.py
+++ b/db/repositories/rpe_dashboard_repo.py
@@ -1,0 +1,321 @@
+# db/repositories/rpe_repo.py
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+import pandas as pd
+from pymongo.errors import PyMongoError
+
+from ..base import BaseRepository
+from ..errors import DatabaseError, ApplicationError
+
+
+class RpeDashboardRepository(BaseRepository):
+    """Repository for RPE reads/aggregations (collection: 'player_rpe')."""
+
+    def __init__(self, db):
+        super().__init__(db, "player_rpe")
+        self.sessions = db["sessions"]
+        self.roster = db["roster"]
+
+
+
+    # ---------------- Aggregate weekly loads + A:C ratio ----------------
+    def get_rpe_loads(self, *, team: Optional[str] = None) -> pd.DataFrame:
+        """Aggregate weekly RPE loads per player.
+
+        Args:
+            team: Optional team filter.
+
+        Returns:
+            DataFrame with columns: player_id, player_name, team, week, load, acute, chronic, acr.
+
+        Raises:
+            DatabaseError: On MongoDB errors.
+
+        Pipeline:
+            - Lookup sessions and roster
+            - Compute effective_minutes
+            - Compute load = RPE * minutes
+            - Group by player/week
+            - Add rolling acute:chronic ratio
+        """
+        try:
+            pipeline: List[Dict[str, Any]] = [
+                {"$lookup": {
+                    "from": "sessions",
+                    "localField": "session_id",
+                    "foreignField": "session_id",
+                    "as": "session"
+                }},
+                {"$unwind": "$session"},
+            ]
+
+            if team:
+                pipeline.append({"$match": {"session.team": team}})
+
+            pipeline.extend([
+                {"$lookup": {
+                    "from": "roster",
+                    "localField": "player_id",
+                    "foreignField": "player_id",
+                    "as": "player"
+                }},
+                {"$unwind": "$player"},
+                {"$addFields": {
+                    "player_name": {
+                        "$concat": ["$player.player_last_name", ", ", "$player.player_first_name"]
+                    },
+                    "week": {"$isoWeek": "$session.date"},
+                    "effective_minutes": {
+                        "$cond": {
+                            "if": {"$gt": ["$training_minutes", 0]},
+                            "then": "$training_minutes",
+                            "else": "$session.duration"
+                        }
+                    },
+                    "load": {
+                        "$multiply": [
+                            "$rpe_score",
+                            {
+                                "$cond": {
+                                    "if": {"$gt": ["$training_minutes", 0]},
+                                    "then": "$training_minutes",
+                                    "else": "$session.duration"
+                                }
+                            }
+                        ]
+                    }
+                }},
+                {"$group": {
+                    "_id": {
+                        "player_id": "$player_id",
+                        "player_name": "$player_name",
+                        "team": "$session.team",
+                        "week": "$week"
+                    },
+                    "load": {"$sum": "$load"}
+                }},
+                {"$project": {
+                    "_id": 0,
+                    "player_id": "$_id.player_id",
+                    "player_name": "$_id.player_name",
+                    "team": "$_id.team",
+                    "week": "$_id.week",
+                    "load": 1
+                }},
+                {"$sort": {"player_name": 1, "week": 1}}
+            ])
+
+            df = pd.DataFrame(list(self.col.aggregate(pipeline)))
+            if df.empty:
+                return df
+
+            # Rolling metrics (per player, ordered by week)
+            df = df.sort_values(by=["player_name", "week"])
+            df["acute"] = df.groupby("player_name")["load"].transform(lambda x: x.rolling(1, min_periods=1).mean())
+            df["chronic"] = df.groupby("player_name")["load"].transform(lambda x: x.shift().rolling(4, min_periods=1).mean())
+            df["acr"] = (df["acute"] / df["chronic"]).round(2)
+
+            return df
+
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to fetch RPE loads: {e}") from e
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_rpe_loads: {e}") from e
+
+
+
+    # ---------------- Daily overview pivot ----------------
+    def get_daily_rpe_overview(self, *, team: Optional[str] = None) -> pd.DataFrame:
+        """
+        Returns a pivot table with one row per player (from roster),
+        one column per date, and cell text "rpe_score | training_minutes".
+        - Players with no entries are still shown.
+        - If multiple entries exist for the same player/day, the latest by timestamp wins.
+        - training_minutes defaults to the session's duration when missing/zero.
+        """
+        try:
+            rpe_data = list(self.col.find({}, {"_id": 0}))
+            roster_data = list(self.roster.find({}, {"_id": 0}))
+            sessions_data = list(self.sessions.find({}, {"_id": 0, "session_id": 1, "duration": 1}))
+
+            if not roster_data:
+                return pd.DataFrame()
+
+            rpe_df = pd.DataFrame(rpe_data)
+            roster_df = pd.DataFrame(roster_data)
+            sessions_df = pd.DataFrame(sessions_data)
+
+            # roster normalization
+            roster_df["player_id"] = pd.to_numeric(roster_df["player_id"], errors="coerce").astype("Int64")
+            roster_df["player_name"] = roster_df["player_last_name"].astype(str) + ", " + roster_df["player_first_name"].astype(str)
+            if team:
+                roster_df = roster_df[roster_df["team"] == team]
+
+            if rpe_df.empty:
+                # Return player index (no date cols)
+                return roster_df[["player_name"]].drop_duplicates().set_index("player_name")
+
+            # rpe normalization
+            rpe_df["player_id"] = pd.to_numeric(rpe_df["player_id"], errors="coerce").astype("Int64")
+            rpe_df["date"] = pd.to_datetime(rpe_df["date"], errors="coerce").dt.date
+
+            def _to_ts(x):
+                if isinstance(x, dict) and "$date" in x:
+                    return pd.to_datetime(x["$date"], errors="coerce")
+                return pd.to_datetime(x, errors="coerce")
+
+            rpe_df["timestamp"] = rpe_df.get("timestamp", pd.NaT).apply(_to_ts)
+
+            # sessions for default minutes
+            if sessions_df.empty:
+                sessions_df = pd.DataFrame(columns=["session_id", "duration"])
+                sessions_df["duration"] = pd.Series(dtype="Int64")
+            else:
+                sessions_df["duration"] = pd.to_numeric(sessions_df["duration"], errors="coerce").fillna(0).astype(int)
+
+            rpe_df = rpe_df.merge(sessions_df, on="session_id", how="left", suffixes=("", "_session"))
+
+            # effective minutes: prefer training_minutes>0 else session duration
+            if "training_minutes" not in rpe_df.columns:
+                rpe_df["training_minutes"] = pd.NA
+            rpe_df["training_minutes"] = pd.to_numeric(rpe_df["training_minutes"], errors="coerce").fillna(0)
+
+            rpe_df["effective_minutes"] = rpe_df.apply(
+                lambda row: int(row["training_minutes"]) if row["training_minutes"] > 0
+                else int(row["duration"]) if pd.notna(row["duration"]) and row["duration"] > 0
+                else 0,
+                axis=1
+            )
+
+            # keep latest per (player_id, date)
+            rpe_df = rpe_df.sort_values(["player_id", "date", "timestamp"])
+            rpe_latest = rpe_df.drop_duplicates(subset=["player_id", "date"], keep="last")
+
+            rpe_latest["entry"] = rpe_latest["rpe_score"].astype(str) + " | " + rpe_latest["effective_minutes"].astype(int).astype(str)
+
+            merged = rpe_latest.merge(roster_df[["player_id", "player_name"]], on="player_id", how="right")
+
+            pivot = merged.pivot_table(index="player_name", columns="date", values="entry", aggfunc="first")
+
+            # ensure all players appear
+            full_players = roster_df[["player_name"]].drop_duplicates().set_index("player_name")
+            full_overview = full_players.join(pivot, how="left").fillna("–")
+
+            # sort rows/cols and tidy
+            full_overview = full_overview.sort_index(axis=0)
+            if full_overview.shape[1] > 0:
+                full_overview = full_overview.sort_index(axis=1)
+                full_overview.columns = full_overview.columns.astype(str)
+            full_overview.index.name = None
+
+            return full_overview
+
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to generate RPE overview: {e}") from e
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_daily_rpe_overview: {e}") from e
+
+
+
+    # ---------------- Raw RPE df ----------------
+    def get_player_rpe_df(self) -> pd.DataFrame:
+        """Return all RPE registrations (projected columns)."""
+        try:
+            proj = {
+                "_id": 0,
+                "player_id": 1,
+                "session_id": 1,
+                "date": 1,
+                "rpe_score": 1,
+                "training_minutes": 1,
+                "timestamp": 1,
+            }
+            return pd.DataFrame(list(self.col.find({}, proj)))
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to load RPE: {e}") from e
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_player_rpe_df: {e}") from e
+        
+
+
+    # ---------------- Session dashboard aggregates ----------------
+    def get_session_rpe_aggregates(self, *, team: str | None = None) -> list[dict]:
+        """
+        Aggregates RPE data for the session dashboard.
+
+        Returns a list of dicts with:
+          - week (int)
+          - session_type (str)
+          - total_load (float)
+          - session_count (int)
+          - player_count (int)
+        """
+        try:
+            pipeline: list[dict] = [
+                {
+                    "$lookup": {
+                        "from": "sessions",
+                        "localField": "session_id",
+                        "foreignField": "session_id",
+                        "as": "session",
+                    }
+                },
+                {"$unwind": "$session"},
+            ]
+
+            if team:
+                pipeline.append({"$match": {"session.team": team}})
+
+            pipeline += [
+                {
+                    "$project": {
+                        "load": {
+                            "$multiply": [
+                                "$rpe_score",
+                                {
+                                    "$cond": {
+                                        "if": {"$gt": ["$training_minutes", 0]},
+                                        "then": "$training_minutes",
+                                        "else": "$session.duration",
+                                    }
+                                },
+                            ]
+                        },
+                        "weeknumber": "$session.weeknumber",
+                        "session_type": "$session.session_type",
+                        "session_id": "$session.session_id",
+                        "player_id": 1,
+                    }
+                },
+                {
+                    "$group": {
+                        "_id": {
+                            "week": "$weeknumber",
+                            "session_type": "$session_type",
+                        },
+                        "total_load": {"$sum": "$load"},
+                        "sessions": {"$addToSet": "$session_id"},
+                        "players": {"$addToSet": "$player_id"},
+                    }
+                },
+                {
+                    "$project": {
+                        "_id": 0,
+                        "week": "$_id.week",
+                        "session_type": "$_id.session_type",
+                        "total_load": 1,
+                        "session_count": {"$size": "$sessions"},
+                        "player_count": {"$size": "$players"},
+                    }
+                },
+                {"$sort": {"week": 1, "session_type": 1}},
+            ]
+
+            return list(self.col.aggregate(pipeline))
+
+        except PyMongoError as e:
+            from ..errors import DatabaseError
+            raise DatabaseError(f"Failed to fetch session RPE aggregates: {e}") from e
+        except Exception as e:
+            from ..errors import ApplicationError
+            raise ApplicationError(f"Unexpected error in get_session_rpe_aggregates: {e}") from e

--- a/db/repositories/session_dashboard_repo.py
+++ b/db/repositories/session_dashboard_repo.py
@@ -12,7 +12,7 @@ from typing import Optional, List, Dict, Any, Tuple
 from datetime import date as date_cls
 from datetime import datetime, timedelta    
 import pandas as pd
-# from pymongo.errors import PyMongoError
+from pymongo.errors import PyMongoError
 from db.errors import DatabaseError  # your central error type
 
 

--- a/db/repositories/session_dashboard_repo.py
+++ b/db/repositories/session_dashboard_repo.py
@@ -1,0 +1,145 @@
+"""
+Session Dashboard Repository
+Centralizes DB access for the session dashboard.
+
+Collections assumed:
+- sessions: {_id, date (ISO string), team, session_type, duration, ...}
+- player_rpe: {_id, player_id, session_id, rpe_score|rpe, training_minutes, timestamp, ...}
+"""
+
+from __future__ import annotations
+from typing import Optional, List, Dict, Any
+from datetime import date as date_cls
+import pandas as pd
+from pymongo.errors import PyMongoError
+from db.errors import DatabaseError  # your central error type
+
+
+# Optional: align with your existing custom error
+try:
+    from db.mongo_wrapper import DatabaseError
+except Exception:  # fallback if not present
+    class DatabaseError(RuntimeError):
+        """Generic DB error wrapper for the dashboard."""
+
+
+def _date_bounds(
+    date_from: Optional[date_cls],
+    date_to: Optional[date_cls],
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Convert date range to ISO strings for Mongo match (inclusive start, exclusive end).
+    """
+    if date_from:
+        start = datetime.combine(date_from, datetime.min.time()).date().isoformat()
+    else:
+        start = None
+    if date_to:
+        end = (datetime.combine(date_to, datetime.min.time()) + timedelta(days=1)).date().isoformat()
+    else:
+        end = None
+    return start, end
+
+
+def get_session_rpe_aggregates_df(mongo, team: str) -> pd.DataFrame:
+    """
+    Use your existing MongoWrapper method to fetch weekly/session-type aggregates.
+    Returns a DataFrame with at least:
+        week, session_type, total_load, session_count, player_count
+    """
+    try:
+        data = mongo.get_session_rpe_aggregates(team=team)  # ← your existing method
+        df = pd.DataFrame(data or [])
+        if df.empty:
+            return df
+        # Defensive: ensure numeric columns
+        for col in ("total_load", "session_count", "player_count"):
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+        return df
+    except Exception as e:
+        raise DatabaseError(f"Failed to fetch session aggregates: {e}") from e
+
+
+def get_rpe_joined_per_session_df(
+    _mongo,
+    team: str,
+    date_from: Optional[date_cls] = None,
+    date_to: Optional[date_cls] = None,
+) -> pd.DataFrame:
+    """
+    Per-player RPE rows joined to sessions via session_id (same as get_rpe_loads).
+    Returns columns:
+        session_id, date (datetime64), session_type, player_id, rpe, training_minutes, duration
+    """
+    try:
+        # --- Build aggregation pipeline mirroring get_rpe_loads join logic ---
+        pipeline: List[Dict[str, Any]] = [
+            # Join player_rpe → sessions ON session_id (not _id)
+            {"$lookup": {
+                "from": "sessions",
+                "localField": "session_id",
+                "foreignField": "session_id",
+                "as": "session"
+            }},
+            {"$unwind": "$session"},
+        ]
+
+        # Optional team filter (same as your get_rpe_loads)
+        if team:
+            pipeline.append({"$match": {"session.team": team}})
+
+        # Optional date filter on session.date (your get_rpe_loads uses $isoWeek on a Date,
+        # so we assume sessions.date is a proper BSON Date)
+        date_match: Dict[str, Any] = {}
+        if date_from is not None:
+            # include from
+            date_match["$gte"] = pd.to_datetime(date_from)
+        if date_to is not None:
+            # include to (end of day)
+            date_match["$lte"] = pd.to_datetime(date_to) + pd.Timedelta(days=1) - pd.Timedelta(microseconds=1)
+        if date_match:
+            pipeline.append({"$match": {"session.date": date_match}})
+
+        # Shape the fields we need for a boxplot
+        pipeline.extend([
+            {"$project": {
+                "_id": 0,
+                "player_id": 1,
+                # prefer rpe_score, fall back to rpe
+                "rpe": {"$ifNull": ["$rpe_score", "$rpe"]},
+                "training_minutes": 1,
+                "timestamp": 1,
+                "session_id": "$session.session_id",
+                "date": "$session.date",
+                "team": "$session.team",
+                "session_type": "$session.session_type",
+                "duration": "$session.duration"
+            }},
+            # drop records with missing rpe or date
+            {"$match": {"rpe": {"$ne": None}, "date": {"$ne": None}}}
+        ])
+
+        rows = list(_mongo.db["player_rpe"].aggregate(pipeline))
+        df = pd.DataFrame(rows)
+        if df.empty:
+            return df
+
+        # Normalize types
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        df["rpe"] = pd.to_numeric(df["rpe"], errors="coerce")
+        if "training_minutes" in df.columns:
+            df["training_minutes"] = pd.to_numeric(df["training_minutes"], errors="coerce")
+
+        # Final clean
+        df = df.dropna(subset=["date", "rpe"])
+
+        # Keep tidy column order
+        cols = [
+            "session_id", "date", "team", "session_type", "duration",
+            "player_id", "rpe", "training_minutes", "timestamp"
+        ]
+        return df[[c for c in cols if c in df.columns]]
+
+    except PyMongoError as e:
+        raise DatabaseError(f"Failed to fetch per-session RPE distribution: {e}") from e

--- a/db/repositories/session_dashboard_repo.py
+++ b/db/repositories/session_dashboard_repo.py
@@ -12,7 +12,7 @@ from typing import Optional, List, Dict, Any, Tuple
 from datetime import date as date_cls
 from datetime import datetime, timedelta    
 import pandas as pd
-from pymongo.errors import PyMongoError
+# from pymongo.errors import PyMongoError
 from db.errors import DatabaseError  # your central error type
 
 

--- a/db/repositories/session_dashboard_repo.py
+++ b/db/repositories/session_dashboard_repo.py
@@ -8,8 +8,9 @@ Collections assumed:
 """
 
 from __future__ import annotations
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 from datetime import date as date_cls
+from datetime import datetime, timedelta    
 import pandas as pd
 from pymongo.errors import PyMongoError
 from db.errors import DatabaseError  # your central error type
@@ -41,6 +42,7 @@ def _date_bounds(
     return start, end
 
 
+
 def get_session_rpe_aggregates_df(mongo, team: str) -> pd.DataFrame:
     """
     Use your existing MongoWrapper method to fetch weekly/session-type aggregates.
@@ -59,6 +61,7 @@ def get_session_rpe_aggregates_df(mongo, team: str) -> pd.DataFrame:
         return df
     except Exception as e:
         raise DatabaseError(f"Failed to fetch session aggregates: {e}") from e
+
 
 
 def get_rpe_joined_per_session_df(

--- a/db/repositories/sessions_repo.py
+++ b/db/repositories/sessions_repo.py
@@ -1,0 +1,123 @@
+# db/repositories/sessions_repo.py
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from typing import Any, Dict, List, Optional
+import pandas as pd
+
+from ..base import BaseRepository
+from ..errors import DatabaseError, ApplicationError
+
+
+def _as_datetime(d: date | datetime) -> datetime:
+    """Normalize a date or datetime to a datetime (midnight if date)."""
+    if isinstance(d, datetime):
+        return d
+    if isinstance(d, date):
+        return datetime.combine(d, time.min)
+    raise ApplicationError(f"Invalid 'date' type: {type(d)}")
+
+
+class SessionsRepository(BaseRepository):
+    """DB access for training sessions and matches (collection: 'sessions')."""
+
+    def __init__(self, db):
+        super().__init__(db, "sessions")
+
+    # ---------- Write ----------
+    def add_session(self, *, session_data: Dict[str, Any]) -> bool:
+        """Insert a new session or match.
+
+        Required keys in session_data:
+            - date: datetime | date
+            - team: str (e.g., "U18", "U21")
+            - session_type: str ("T1", "T2", "T3" or "T4" for training, "M" for match)
+            - duration: int (minutes) — optional but recommended
+
+        Side-effects:
+            - Normalizes `date` to datetime.
+            - Sets `weeknumber` (ISO week).
+            - Generates `session_id` as YYYYMMDD + team (e.g., 20250115U18).
+
+        Raises:
+            ApplicationError: if required keys are missing/invalid.
+            DatabaseError: on MongoDB failure (e.g., duplicate session_id).
+        """
+        try:
+            required = ["date", "team", "session_type"]
+            missing = [k for k in required if k not in session_data]
+            if missing:
+                raise ApplicationError(f"add_session: missing fields: {', '.join(missing)}")
+
+            dt = _as_datetime(session_data["date"])
+            team = str(session_data["team"])
+            if not team:
+                raise ApplicationError("add_session: 'team' cannot be empty.")
+
+            session_id = dt.strftime("%Y%m%d") + team
+            session_doc = dict(session_data)  # shallow copy
+            session_doc["date"] = dt
+            session_doc["weeknumber"] = dt.isocalendar().week
+            session_doc["session_id"] = session_id
+
+            self.insert_one_safe(session_doc)  # raises DatabaseError on failure
+            return True
+
+        except DatabaseError:
+            raise
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in add_session: {e}") from e
+
+    # ---------- Read ----------
+    def get_sessions_df(
+        self,
+        *,
+        team: Optional[str] = None,
+        session_type: Optional[str] = None,
+        date_from: Optional[date | datetime] = None,
+        date_to: Optional[date | datetime] = None,
+        projection: Optional[Dict[str, int]] = None,
+    ) -> pd.DataFrame:
+        """Return sessions as a DataFrame, with optional filters.
+
+        Args:
+            team: Filter by team (e.g., "U18"). If None, return all teams.
+            session_type: ("T1", "T2", "T3" or "T4" for training, "M" for match)
+            date_from: inclusive lower bound on `date`.
+            date_to: exclusive upper bound on `date` (use end-of-day if you pass a date).
+
+        Returns:
+            pandas.DataFrame without `_id`.
+
+        Raises:
+            DatabaseError: on MongoDB failure.
+            ApplicationError: on parameter errors.
+        """
+        q: Dict[str, Any] = {}
+        if team:
+            q["team"] = team
+        if session_type:
+            q["session_type"] = session_type
+
+        if date_from or date_to:
+            dr: Dict[str, Any] = {}
+            if date_from:
+                dr["$gte"] = _as_datetime(date_from)
+            if date_to:
+                # if a plain date is provided, treat as end-of-day exclusive
+                if isinstance(date_to, date) and not isinstance(date_to, datetime):
+                    date_to = datetime.combine(date_to, time.max)
+                dr["$lt"] = _as_datetime(date_to)
+            q["date"] = dr
+
+        proj = {"_id": 0}
+        if projection:
+            proj.update(projection)
+
+        try:
+            docs: List[Dict[str, Any]] = self.find_safe(q, proj)
+            return pd.DataFrame(docs)
+        except DatabaseError:
+            raise
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_sessions_df: {e}") from e

--- a/db/repositories/wellness_dash_repo.py
+++ b/db/repositories/wellness_dash_repo.py
@@ -1,0 +1,173 @@
+# db/repositories/wellness_repo.py
+from __future__ import annotations
+from datetime import date, datetime, time
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+from pymongo.errors import PyMongoError
+
+from ..base import BaseRepository
+from ..errors import DatabaseError, ApplicationError
+
+
+class WellnessDashboardRepository(BaseRepository):
+    """
+    Repository for wellness entries (collection: 'player_wellness') and
+    the derived wellness views used by dashboards.
+    """
+
+    def __init__(self, db):
+        super().__init__(db, "player_wellness")
+        # We also read from 'roster' for joins
+        self.roster = db["roster"]
+
+    # ------------------ TODAY ENTRIES ------------------
+    def get_today_wellness_entries(self, *, team: str, target_date: Optional[date] = None) -> List[Dict[str, Any]]:
+        """Returns wellness entries for the given day for players in `team`."""
+        if not team:
+            raise ApplicationError("get_today_wellness_entries: 'team' is required.")
+        if target_date is None:
+            target_date = date.today()
+
+        start_ts = datetime.combine(target_date, time.min)
+        end_ts = datetime.combine(target_date, time.max)
+
+        try:
+            # fetch player_ids for team (minimal projection)
+            player_ids = [int(d["player_id"]) for d in self.roster.find({"team": team}, {"_id": 0, "player_id": 1})]
+            if not player_ids:
+                return []
+
+            return list(
+                self.col.find(
+                    {"player_id": {"$in": player_ids}, "timestamp": {"$gte": start_ts, "$lte": end_ts}},
+                    {"_id": 0},
+                )
+            )
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to fetch today's wellness entries: {e}") from e
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_today_wellness_entries: {e}") from e
+
+    # ------------------ WEEKLY MATRIX (datatable) ------------------
+    def get_wellness_matrix(self, *, team: Optional[str] = None) -> pd.DataFrame:
+        """Return weekly average wellness per player in pivot form.
+
+        Args:
+            team: Optional filter ("U18" or "U21").
+
+        Returns:
+            DataFrame with player_name as rows and weeks as columns. 
+            Cell values formatted as "avg_feeling | avg_sleeping".
+
+        Raises:
+            DatabaseError: On MongoDB error.
+
+        Notes:
+            - Season start hard-coded as first Monday of August 2025.
+            - Week labels formatted as "W00", "W01", ...
+        """
+        try:
+            wellness_docs = list(self.col.find({}, {"_id": 0}))
+            wellness_df = pd.DataFrame(wellness_docs)
+            if wellness_df.empty:
+                return pd.DataFrame(columns=["player_name"])
+
+            # Normalize types
+            wellness_df["player_id"] = wellness_df["player_id"].astype(str)
+            wellness_df["date"] = pd.to_datetime(wellness_df["date"], errors="coerce")
+
+            # Get season start (import lazy to avoid repo↔utils coupling at import time)
+            try:
+                from utils.constants import REGISTRATION_START_DATE
+                season_start = pd.to_datetime(REGISTRATION_START_DATE)
+            except Exception:
+                # fallback: August 1st current year
+                season_start = pd.to_datetime(f"{datetime.now().year}-08-01")
+
+            # Compute 0-based season week
+            wellness_df["season_week"] = ((wellness_df["date"] - season_start).dt.days // 7).astype("Int64")
+
+            # Weekly means
+            weekly_avg = (
+                wellness_df.groupby(["player_id", "season_week"], dropna=True)
+                .agg(avg_feeling=("feeling", "mean"), avg_sleeping=("sleep_hours", "mean"))
+                .reset_index()
+            )
+
+            if weekly_avg.empty:
+                return pd.DataFrame(columns=["player_name"])
+
+            weekly_avg["combined"] = weekly_avg.apply(
+                lambda r: f"{r['avg_feeling']:.1f} | {r['avg_sleeping']:.1f}", axis=1
+            )
+
+            # Load roster & join
+            roster_docs = list(self.roster.find({}, {"_id": 0, "player_id": 1, "player_first_name": 1, "player_last_name": 1, "team": 1}))
+            roster_df = pd.DataFrame(roster_docs)
+            if roster_df.empty:
+                return pd.DataFrame(columns=["player_name"])
+
+            roster_df["player_id"] = roster_df["player_id"].astype(str)
+            roster_df["player_name"] = roster_df["player_last_name"].astype(str) + ", " + roster_df["player_first_name"].astype(str)
+
+            if team:
+                roster_df = roster_df[roster_df["team"] == team]
+
+            merged = weekly_avg.merge(roster_df[["player_id", "player_name"]], on="player_id", how="inner")
+            merged["week_label"] = "W" + merged["season_week"].astype(str).str.zfill(2)
+
+            compact_df = merged.pivot(index="player_name", columns="week_label", values="combined")
+            return compact_df.reset_index().sort_values("player_name")
+
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to build compact wellness table: {e}") from e
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_wellness_matrix: {e}") from e
+
+    # ------------------ DAILY OVERVIEW (pivot) ------------------
+    def get_daily_wellness_overview(self, *, team: Optional[str] = None) -> pd.DataFrame:
+        """Return pivot: rows players, columns dates, values 'feeling | sleep_hours'."""
+        try:
+            wellness_docs = list(self.col.find({}, {"_id": 0}))
+            roster_docs = list(self.roster.find({}, {"_id": 0}))
+
+            if not roster_docs:
+                return pd.DataFrame()
+
+            wellness_df = pd.DataFrame(wellness_docs)
+            roster_df = pd.DataFrame(roster_docs)
+
+            roster_df["player_id"] = pd.to_numeric(roster_df["player_id"], errors="coerce").astype("Int64")
+
+            if not wellness_df.empty:
+                wellness_df["player_id"] = pd.to_numeric(wellness_df["player_id"], errors="coerce").astype("Int64")
+                wellness_df["date"] = pd.to_datetime(wellness_df["date"], errors="coerce").dt.date
+                wellness_df["entry"] = wellness_df["feeling"].astype(str) + " | " + wellness_df["sleep_hours"].astype(str)
+
+                roster_df["player_name"] = roster_df["player_last_name"].astype(str) + ", " + roster_df["player_first_name"].astype(str)
+                merged = wellness_df.merge(roster_df[["player_id", "player_name", "team"]], on="player_id", how="left")
+
+                if team:
+                    merged = merged[merged["team"] == team]
+
+                pivot = merged.pivot_table(index="player_name", columns="date", values="entry", aggfunc="first")
+            else:
+                pivot = pd.DataFrame()
+
+            roster_df["player_name"] = roster_df["player_last_name"].astype(str) + ", " + roster_df["player_first_name"].astype(str)
+            if team:
+                roster_df = roster_df[roster_df["team"] == team]
+
+            full_players = roster_df[["player_name"]].drop_duplicates().set_index("player_name")
+            full_overview = full_players.join(pivot, how="left").fillna("–")
+            full_overview = full_overview.sort_index(axis=0).sort_index(axis=1)
+            full_overview.columns = full_overview.columns.astype(str)
+            full_overview.index.name = None
+
+            return full_overview
+
+        except PyMongoError as e:
+            raise DatabaseError(f"Failed to generate wellness overview: {e}") from e
+        except Exception as e:
+            raise ApplicationError(f"Unexpected error in get_daily_wellness_overview: {e}") from e

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,190 @@
-# Contributing & Documentation Standards
+# Contributing Guide
+
+Welcome 👋 — thanks for helping improve this project.  
+This document explains how to work safely with the codebase, especially during the **ongoing database layer refactor**.
+
+---
+
+## 📦 Branching Strategy
+
+- **`main` branch**
+  - Always stable, production-ready.
+  - Streamlit Cloud deploys directly from `main`.
+  - Hotfixes and small feature requests from users go here.
+
+- **Feature / Refactor branches**
+  - Create a branch for every new feature or refactor.
+  - Naming:  
+    - `feature/<short-name>` for new functionality  
+    - `refactor/<short-name>` for structural changes  
+    - `fix/<short-name>` for bugfixes  
+  - Example:  
+    ~~~bash
+    git checkout -b refactor/db-layer
+    ~~~
+
+---
+
+## 🔄 Workflow
+
+### Everyday cycle
+
+1) **Stay updated**
+   ~~~bash
+   git checkout main
+   git pull origin main
+   ~~~
+
+2) **Create your branch**
+   ~~~bash
+   git checkout -b refactor/db-layer
+   ~~~
+
+3) **Make small, safe changes**
+   - Move **one function at a time** (baby steps).
+   - Keep public method signatures unchanged until all call sites are updated.
+   - Run the app locally (`streamlit run main.py`) after each step.
+
+4) **Commit often**
+   ~~~bash
+   git add -A
+   git commit -m "refactor(roster): delegate get_player_names to RosterRepository"
+   ~~~
+
+5) **Push to GitHub**
+   ~~~bash
+   git push -u origin refactor/db-layer
+   ~~~
+
+---
+
+## ✅ Baby-Step Refactor Checklist
+
+- [ ] Public API unchanged (e.g. `mongo.get_player_names(...)` still works).
+- [ ] Moved logic wrapped in a repository or service.
+- [ ] App boots without exceptions.
+- [ ] UI behavior unchanged on affected pages.
+- [ ] No stray imports from views into `db/*`.
+
+When this is true → commit!
+
+---
+
+## 🚦 Error Handling Guidelines
+
+- **DatabaseError**  
+  Raised when MongoDB operations fail.
+
+- **ApplicationError**  
+  Raised when application logic fails (bad data, formatting issues, invalid input).
+
+- **AppError (base class)** *(optional later)*  
+  Both `DatabaseError` and `ApplicationError` can inherit from this for unified catching.
+
+**Example usage in a view**
+~~~python
+try:
+    players = mongo.get_player_names(team="U21")
+except DatabaseError as e:
+    st.error(f"Database error: {e}")
+except ApplicationError as e:
+    st.error(f"Application error: {e}")
+~~~
+
+---
+
+## 🔄 Syncing with `main`
+
+While on your branch:
+~~~bash
+git fetch origin
+git merge origin/main
+~~~
+
+Resolve conflicts if needed, then retest locally.
+
+---
+
+## 🛑 Rollback
+
+If something goes wrong:
+
+- Undo last commit (not pushed):
+  ~~~bash
+  git reset --hard HEAD~1
+  ~~~
+
+- Undo last commit (already pushed):
+  ~~~bash
+  git revert <commit-hash>
+  ~~~
+
+- Delete a failed branch entirely:
+  ~~~bash
+  git checkout main
+  git branch -D refactor/db-layer
+  ~~~
+
+---
+
+## 📝 Commit Message Style
+
+Use **conventional commits**:
+
+- `feat:` → new feature  
+- `fix:` → bug fix  
+- `refactor:` → restructuring, no behavior change  
+- `docs:` → documentation only  
+- `test:` → adding tests  
+- `chore:` → maintenance  
+
+**Examples**
+- `refactor(roster): delegate get_player_names to RosterRepository`  
+- `fix(attendance): correct date filter logic`  
+- `feat(pdp): add priority flag to PDP topics`
+
+---
+
+## 🌱 Best Practices
+
+- Keep PRs **small and focused** — easier to review and rollback.
+- One responsibility per repo:
+  - `RosterRepository` → roster-related queries
+  - `SessionsRepository` → sessions
+  - `WellnessRepository` → wellness, etc.
+- Views (Streamlit pages) never talk directly to MongoDB — always via repos or services.
+- Write docstrings with clear **Args/Returns**.
+
+---
+
+## 📋 Pull Request Template
+
+**Summary**  
+Explain the change in 2–3 sentences.
+
+**Changes**
+- [ ] Extracted `<method>` into `<RepoClass>`
+- [ ] Delegated old method in `MongoWrapper`
+- [ ] Verified `<affected page>` renders correctly
+
+**Checklist**
+- [ ] Tested locally with real data  
+- [ ] No new linter warnings/errors  
+- [ ] Commit messages follow conventional format  
+
+---
+
+## 🔀 Visual Branching (for reference)
+
+~~~text
+main ──●──────●────────●─────────────●─────────►
+         \                \
+          \                \__ (hotfix) merge into main
+           \
+            └── refactor/db-layer ─●──●──●─────► (PR → main)
+~~~
+
+# Documentation Standards
 
 ## Docstrings
 - **Style**: Google-style docstrings.

--- a/docs/dashboards/injury_overview.md
+++ b/docs/dashboards/injury_overview.md
@@ -1,0 +1,36 @@
+# Injury Overview View
+
+## Purpose
+The Injury Overview page provides coaches, analysts, and medical staff with 
+a consolidated overview of all player injuries for a selected team. It is a 
+**read-only** view designed for monitoring player status, not for editing.
+
+## Features
+- Team selector (`U18`, `U21`, …) using the shared component.
+- Injury entries displayed in expandable panels:
+  - Player name
+  - Description
+  - Current status
+- Shaded two-column detail block with:
+  - Injury date
+  - Diagnostic / doctor details
+  - Imagery type
+  - Projected duration
+  - Comments
+- Treatment sessions section with expandable session notes:
+  - Session date
+  - Author
+  - Comment
+  - Post-session status
+
+## Data Sources
+- **`injuries` collection** (via `InjuryRepo`)
+- **`roster` collection** for player display names
+
+## Notes
+- This view is **read-only**. Injury creation and updates are handled elsewhere.
+- Import-safe: no database writes or side effects on import.
+- Displays user-friendly messages when no team, no players, or no injuries exist.
+
+## Example Screenshot
+*(Insert Streamlit screenshot here once the page is live in the app)*

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,4 @@
+# Error Types
+
+::: db.errors.DatabaseError
+::: db.errors.ApplicationError

--- a/docs/reference/legacy_mongo_wrapper.md
+++ b/docs/reference/legacy_mongo_wrapper.md
@@ -1,0 +1,10 @@
+# Legacy Mongo Wrapper (Compatibility)
+
+> **Note:** This wrapper is kept temporarily during the refactor to avoid breaking pages.
+> Prefer using Repositories and Services directly in new code.
+
+::: db.mongo_wrapper.MongoWrapper
+    options:
+      show_docstring_description: true
+      filters:
+        - "!^__"   # hide dunders

--- a/docs/reference/repositories.md
+++ b/docs/reference/repositories.md
@@ -1,0 +1,17 @@
+# Repositories (DB access layer)
+
+These are thin classes that talk directly to MongoDB via `pymongo`.  
+Business logic should live in Services (if present), not here.
+
+## Roster
+::: db.repositories.roster_repo.RosterRepository
+    options:
+      members:
+        - get_player_names
+      show_docstring_description: true
+
+## Sessions
+::: db.repositories.sessions_repo.SessionsRepository
+
+## Attendance / Match Minutes
+::: db.repositories.attendance_repo.MatchMinutesRepository

--- a/docs/reference/repositories.md
+++ b/docs/reference/repositories.md
@@ -20,13 +20,22 @@ Business logic should live in Services (if present), not here.
         - get_sessions_df
       show_docstring_description: true
 
-## PDP Structures
+## PDP Structure
 ::: db.repositories.pdp_repo.PdpRepository
     options:
       members:
         - get_pdp_structure_for_team
         - update_pdp_structure_for_team
         - list_all_team_structures
+      show_docstring_description: true
+
+## Player PDP
+::: db.repositories.player_pdp_repo.PlayerPdpRepository
+    options:
+      members:
+        - get_latest_pdp_for_player
+        - get_all_pdps_for_player
+        - insert_new_pdp
       show_docstring_description: true
 
 ## Attendance / Match Minutes

--- a/docs/reference/repositories.md
+++ b/docs/reference/repositories.md
@@ -20,5 +20,14 @@ Business logic should live in Services (if present), not here.
         - get_sessions_df
       show_docstring_description: true
 
+## PDP Structures
+::: db.repositories.pdp_repo.PdpRepository
+    options:
+      members:
+        - get_pdp_structure_for_team
+        - update_pdp_structure_for_team
+        - list_all_team_structures
+      show_docstring_description: true
+
 ## Attendance / Match Minutes
 ::: db.repositories.attendance_repo.MatchMinutesRepository

--- a/docs/reference/repositories.md
+++ b/docs/reference/repositories.md
@@ -8,10 +8,17 @@ Business logic should live in Services (if present), not here.
     options:
       members:
         - get_player_names
+        - get_roster_df
+        - save_roster_df
       show_docstring_description: true
 
 ## Sessions
 ::: db.repositories.sessions_repo.SessionsRepository
+    options:
+      members:
+        - add_session
+        - get_sessions_df
+      show_docstring_description: true
 
 ## Attendance / Match Minutes
 ::: db.repositories.attendance_repo.MatchMinutesRepository

--- a/docs/reference/repositories.md
+++ b/docs/reference/repositories.md
@@ -20,6 +20,16 @@ Business logic should live in Services (if present), not here.
         - get_sessions_df
       show_docstring_description: true
 
+## Session Dashboard Repository
+
+::: db.repositories.session_dashboard_repo
+    options:
+      show_root_heading: true
+      show_source: true
+      members_order: source
+      filters:
+        - "!^_"
+
 ## PDP Structure
 ::: db.repositories.pdp_repo.PdpRepository
     options:

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -1,0 +1,6 @@
+# Services (Business logic)
+
+Services compose multiple repositories and add business rules.
+
+## Minutes Service
+::: services.minutes_service.MinutesService

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ plugins:
             show_signature_annotations: true
             merge_init_into_class: true
             show_source: true
+            separate_signature: true
+            summary: true
   - git-revision-date-localized:
       fallback_to_build_date: true
 
@@ -69,5 +71,9 @@ nav:
       - Glossary: data/glossary.md
   - Reference:
       - Technical reference: reference/api.md
+      - Repositories (DB layer): reference/repositories.md
+      - Services (Business layer): reference/services.md
+      - Errors: reference/errors.md
+      - Legacy MongoWrapper: reference/legacy_mongo_wrapper.md
       - Changelog: reference/changelog.md
   - Contributing: contributing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - Wellness Dashboard: dashboards/wellness_dashboard.md
       - RPE Dashboard: dashboards/rpe_dashboard.md
       - Session Dashboard: dashboards/session_dashboard.md
+      - Injury Overview: dashboards/injury_overview.md
   - PDP:
       - Create PDP: pdp/create_pdp.md
       - PDP Library: pdp/pdp_library.md

--- a/views/injury_management.py
+++ b/views/injury_management.py
@@ -56,7 +56,7 @@ def render(mongo, user):
     with tab1:
         st.subheader(":material/assist_walker: Register New Injury")
 
-        with st.form("register_injury_form"):
+        with st.form("register_injury_form", clear_on_submit=True):
             injury_date = st.date_input("Date of Injury", value=date.today(), width=200)
 
             # Description and Diagnostic side by side

--- a/views/injury_overview.py
+++ b/views/injury_overview.py
@@ -1,9 +1,24 @@
+"""Injury Overview view (read-only).
+
+This page provides coaches and staff with an overview of all injuries 
+within a selected team. Each injury entry includes core details, current 
+status, and associated treatment sessions.
+
+Data source:
+    - Reads from the `injuries` collection via `InjuryRepo`.
+    - Player display names are resolved from the `roster` collection.
+
+Notes:
+    - Import-safe for mkdocstrings (no side effects at import time).
+    - Editing or creating injuries is handled elsewhere (not in this view).
+"""
+
 from __future__ import annotations
 from typing import Dict, Any, List
 
 import streamlit as st
 
-from db.repositories.injury_repo import InjuryRepo
+from db.repositories.injury_repo import InjuryRepository
 from db.errors import DatabaseError
 from utils.team_selector import team_selector
 from utils.constants import TEAMS
@@ -59,7 +74,7 @@ def render(mongo, user: str):
     id_to_name = {p["player_id"]: p["display_name"] for p in players}
 
     # Fetch injuries for the team
-    repo = InjuryRepo(mongo.db)
+    repo = InjuryRepository(mongo.db)
     try:
         injuries = repo.list_injuries_by_team(team)
     except DatabaseError as e:

--- a/views/injury_overview.py
+++ b/views/injury_overview.py
@@ -125,7 +125,7 @@ def render(mongo, user: str):
                     comment = s.get("comment", "—")
                     status_after = s.get("status_after")
                     status_html = (
-                        f" · <span style='color:#2563eb;font-weight:600;'>{status_after}</span>"
+                        f" · {status_after}"
                         if status_after else ""
                     )
                     with st.expander(f"{sd} — {author}{status_html}", expanded=False):

--- a/views/player_pdp.py
+++ b/views/player_pdp.py
@@ -9,12 +9,20 @@ def render(mongo, user):
     st.title(":material/portrait: Create New Player PDP")
 
     # --- Load roster ---
-    roster = mongo.get_roster_players("U18")
+    roster = mongo.get_player_names(team="U18", style="LAST_FIRST", include_inactive=True)
     if not roster:
         st.warning("No players found in roster.")
         return
 
-    player_lookup = {f"{p['player_last_name']}, {p['player_first_name']}": p for p in roster}
+    player_lookup = {p["display_name"]: p for p in roster}
+
+    # # --- Load roster ---
+    # roster = mongo.get_roster_players("U18")
+    # if not roster:
+    #     st.warning("No players found in roster.")
+    #     return
+
+    # player_lookup = {f"{p['player_last_name']}, {p['player_first_name']}": p for p in roster}
     # selected_name = st.selectbox("Select a player", list(player_lookup.keys()))
     # player = player_lookup[selected_name]
     # player_id = player["player_id"]
@@ -128,18 +136,18 @@ def render(mongo, user):
                         }
 
         # --- Save PDP ---
-        submitted = st.form_submit_button("Save PDP")
+        submitted = st.form_submit_button(":material/save: Save PDP")
         if submitted:
-            now = datetime.now().isoformat()
+            now = datetime.datetime.utcnow()
             new_pdp = {
                 "player_id": player_id,
                 "team": team,
-                "created": now,
+                "created_at": now,
                 "last_updated": now,
                 "created_by": user,
                 "last_updated_by": user,
-                "data": form_data
+                "payload": form_data
             }
             mongo.insert_new_pdp(new_pdp)
-            st.success("✅ PDP saved successfully.")
+            st.success("PDP saved successfully.", icon=":material/check_circle:")
             st.session_state["pdp_form_data"] = form_data

--- a/views/player_pdp.py
+++ b/views/player_pdp.py
@@ -1,73 +1,84 @@
 import streamlit as st
+import pandas as pd
 from datetime import datetime
 from copy import deepcopy
-import pandas as pd
 from streamlit.column_config import TextColumn, SelectboxColumn, CheckboxColumn
+
 from utils.ui_utils import get_table_height
+from utils.team_selector import team_selector
+from utils.constants import TEAMS  # e.g., ["U18", "U21"]
+
+from db.errors import DatabaseError, ApplicationError  # if you surface errors
 
 def render(mongo, user):
     st.title(":material/portrait: Create New Player PDP")
 
-    # --- Load roster ---
-    roster = mongo.get_player_names(team="U18", style="LAST_FIRST", include_inactive=True)
+    # --- TEAM SELECTOR ---
+    team = team_selector(TEAMS, widget_key="pdp_team_selector", session_key="pdp_selected_team")
+    if not team:
+        st.info("Select a team to continue.", icon=":material/info:")
+        return
+
+    # --- Load roster (standardized) ---
+    try:
+        roster = mongo.get_player_names(team=team, style="LAST_FIRST", include_inactive=True)
+    except (DatabaseError, ApplicationError) as e:
+        st.error(f"Failed to load roster: {e}")
+        return
+
     if not roster:
-        st.warning("No players found in roster.")
+        st.warning(f"No players found in roster for {team}.")
         return
 
     player_lookup = {p["display_name"]: p for p in roster}
 
-    # # --- Load roster ---
-    # roster = mongo.get_roster_players("U18")
-    # if not roster:
-    #     st.warning("No players found in roster.")
-    #     return
-
-    # player_lookup = {f"{p['player_last_name']}, {p['player_first_name']}": p for p in roster}
-    # selected_name = st.selectbox("Select a player", list(player_lookup.keys()))
-    # player = player_lookup[selected_name]
-    # player_id = player["player_id"]
-    # team = player["team"]
-
-    # --- Prepare form data safely ---
+    # --- Prepare form session state safely ---
     if "pdp_form_data" not in st.session_state:
         st.session_state["pdp_form_data"] = {}
 
     form_data = deepcopy(st.session_state["pdp_form_data"])
 
-    col1, col2, col3 = st.columns([4, 1, 1])
-
+    col1, col2 = st.columns([4, 2])
     with col1:
-        selected_name = st.selectbox("Select a player", list(player_lookup.keys()))
+        selected_name = st.selectbox("Select player", list(player_lookup.keys()), label_visibility="collapsed")
         player = player_lookup[selected_name]
-        player_id = player["player_id"]
-        team = player["team"]
+        player_id = int(player["player_id"])
 
     with col2:
-        st.write("")  # lightweight spacer for alignment
-        if st.button("Start fresh", icon=":material/add_circle_outline:"):
-            st.session_state["pdp_form_data"] = {}
-            st.rerun()
+        bcol1, bcol2 = st.columns(2)
+        with bcol1:
+            if st.button("Start fresh", use_container_width=True, icon=":material/add_circle_outline:"):
+                st.session_state["pdp_form_data"] = {}
+                st.rerun()
+        with bcol2:
+            if st.button("Load last", use_container_width=True, icon=":material/file_open:"):
+                try:
+                    latest = mongo.get_latest_pdp_for_player(player_id)
+                except (DatabaseError, ApplicationError) as e:
+                    st.error(f"Failed to load latest PDP: {e}")
+                    latest = None
 
-    with col3:
-        st.write("")  # lightweight spacer for alignment
-        if st.button("Load last", icon=":material/file_open:"):
-            latest = mongo.get_latest_pdp_for_player(player_id)
-            if latest:
-                st.session_state["pdp_form_data"] = latest["data"]
-                st.success("Last PDP loaded as starting point.")
-            else:
-                st.info("No previous PDP found.")
-            st.rerun()
+                if latest and latest.get("payload"):
+                    st.session_state["pdp_form_data"] = latest["payload"]
+                    st.success("Last PDP loaded as starting point.")
+                else:
+                    st.info("No previous PDP found.")
+                st.rerun()
 
     # --- Load team PDP structure ---
-    structure_doc = mongo.get_pdp_structure_for_team(team)
-    if not structure_doc:
+    try:
+        structure_doc = mongo.get_pdp_structure_for_team(team)
+    except (DatabaseError, ApplicationError) as e:
+        st.error(f"Failed to load PDP structure: {e}")
+        return
+
+    if not structure_doc or "structure" not in structure_doc:
         st.error(f"No PDP structure found for team {team}")
         return
 
     structure = structure_doc["structure"]
 
-    # --- Form rendering ---
+    # --- PDP Form ---
     with st.form("pdp_form"):
         tabs = st.tabs(list(structure.keys()))
 
@@ -78,76 +89,91 @@ def render(mongo, user):
                 if category not in form_data:
                     form_data[category] = {}
 
+                # subcategories inside the category
                 for subcat, topics in structure[category].items():
-                    active_topics = [t for t in topics if t["active"]]
+                    # only active topics
+                    active_topics = [t for t in topics if t.get("active")]
                     if not active_topics:
                         continue
 
                     st.markdown(f"**{subcat}**")
-
                     if subcat not in form_data[category]:
                         form_data[category][subcat] = {}
 
+                    # build editable table rows
                     rows = []
                     for topic in active_topics:
                         topic_name = topic["name"]
-                        current = form_data[category][subcat].get(topic_name, {"score": 3, "priority": False, "comment": ""})
+                        current = form_data[category][subcat].get(
+                            topic_name, {"score": 3, "priority": False, "comment": ""}
+                        )
                         rows.append({
                             "topic": topic_name,
-                            "score": current["score"],
-                            "priority": current["priority"],
-                            "comment": current.get("comment", "")
+                            "score": current.get("score", 3),
+                            "priority": bool(current.get("priority", False)),
+                            "comment": current.get("comment", ""),
                         })
 
+                    # score mapping for UI labels
                     label_to_score = {
                         "1 - Poor": 1,
                         "2 - Fair": 2,
                         "3 - Good": 3,
                         "4 - Very Good": 4,
-                        "5 - Excellent": 5
+                        "5 - Excellent": 5,
                     }
                     score_to_label = {v: k for k, v in label_to_score.items()}
 
+                    # present scores as labels in the editor
                     for row in rows:
                         row["score"] = score_to_label.get(row["score"], "3 - Good")
 
                     df = pd.DataFrame(rows)
                     edited_df = st.data_editor(
                         df,
-                        key=f"editor_{category}_{subcat}",
+                        key=f"editor_{team}_{player_id}_{category}_{subcat}",
                         use_container_width=True,
                         column_config={
                             "topic": TextColumn("Topic", disabled=True, width="large"),
                             "score": SelectboxColumn("Score (1–5)", options=list(label_to_score.keys()), width="medium"),
                             "priority": CheckboxColumn("Priority", width="small"),
-                            "comment": TextColumn("Comment", width="large")
+                            "comment": TextColumn("Comment", width="large"),
                         },
                         height=get_table_height(len(df)),
-                        hide_index=True
+                        hide_index=True,
                     )
 
+                    # map labels back to numeric
                     edited_df["score"] = edited_df["score"].map(label_to_score)
 
+                    # persist into form_data (session_state-backed)
                     for _, row in edited_df.iterrows():
                         form_data[category][subcat][row["topic"]] = {
                             "score": int(row["score"]),
                             "priority": bool(row["priority"]),
-                            "comment": row["comment"].strip()
+                            "comment": str(row["comment"]).strip(),
                         }
 
         # --- Save PDP ---
-        submitted = st.form_submit_button(":material/save: Save PDP")
+        submitted = st.form_submit_button("Save PDP", type="primary", icon=":material/save:")
         if submitted:
-            now = datetime.datetime.utcnow()
-            new_pdp = {
-                "player_id": player_id,
-                "team": team,
-                "created_at": now,
-                "last_updated": now,
-                "created_by": user,
-                "last_updated_by": user,
-                "payload": form_data
-            }
-            mongo.insert_new_pdp(new_pdp)
-            st.success("PDP saved successfully.", icon=":material/check_circle:")
-            st.session_state["pdp_form_data"] = form_data
+            try:
+                now = datetime.utcnow()
+                created_by = user if isinstance(user, str) else getattr(user, "name", str(user))
+
+                new_pdp = {
+                    "player_id": player_id,
+                    "team": team,
+                    "created_at": now,
+                    "last_updated": now,
+                    "created_by": created_by,
+                    "last_updated_by": created_by,
+                    "payload": form_data,
+                }
+
+                _id = mongo.insert_new_pdp(new_pdp)
+                st.success(f"PDP saved successfully (id: {_id}).", icon=":material/check_circle:")
+                st.session_state["pdp_form_data"] = form_data
+
+            except (DatabaseError, ApplicationError) as e:
+                st.error(f"Failed to save PDP: {e}", icon=":material/error_outline:")

--- a/views/roster_management.py
+++ b/views/roster_management.py
@@ -20,6 +20,7 @@ import streamlit as st
 import pandas as pd
 from datetime import datetime
 from db.mongo_wrapper import DatabaseError
+from utils.team_selector import team_selector
 from utils.ui_utils import get_table_height
 
 from utils.constants import TEAMS
@@ -51,63 +52,101 @@ def render(mongo: Any, user: Optional[dict[str, Any]]) -> None:
         "**Adding or removing players must be done by an admin in MongoDB (Compass).**"
     )
 
+    # --- TEAM SELECTOR ---
+    team = team_selector(TEAMS)
+    if not team:
+        st.info("Select a team to continue.", icon=":material/info:")
+        return
+
+    st.caption(f"Editing roster for **{team}**")
+
     try:
-        df: pd.DataFrame = mongo.get_roster_df()
+        team_roster_df: pd.DataFrame = mongo.get_roster_df(team=team)
     except DatabaseError as e:
         st.error(str(e), icon=":material/error_outline")
         return
 
-    # Keep a frozen copy of the original IDs for validation later
-    original_ids = set(pd.to_numeric(df["player_id"], errors="coerce").astype("Int64").dropna().astype(int))
+    # Ensure expected columns when empty
+    if team_roster_df.empty:
+        team_roster_df = pd.DataFrame(columns=["player_id", "player_first_name", "player_last_name", "active"])
 
-    try:
-        edited = st.data_editor(
-            df,
+    # Capture ORIGINAL ids for this team (used in save validation)
+    original_ids = set(
+        pd.to_numeric(team_roster_df.get("player_id", pd.Series(dtype="Int64")), errors="coerce")
+        .astype("Int64").dropna().astype(int)
+    )
+
+    # Prepare the dataframe for the editor (hide 'team' in UI)
+    df_view = team_roster_df.drop(columns=["team"], errors="ignore")
+    if df_view.empty:
+        df_view = pd.DataFrame(columns=["player_id", "player_first_name", "player_last_name", "active"])
+
+    with st.form(f"roster_form_{team}"):
+        edited_df = st.data_editor(
+            df_view,
+            key=f"roster_editor_{team}",
             column_config={
                 "player_id": st.column_config.NumberColumn(
                     "Player ID", required=True, format="%i", disabled=True
                 ),
                 "player_last_name": st.column_config.TextColumn("Last Name", required=True),
                 "player_first_name": st.column_config.TextColumn("First Name", required=True),
-                "team": st.column_config.SelectboxColumn("Team", options=TEAMS, required=True),
-                # Uncomment when needed:
-                # "date_of_birth": st.column_config.DateColumn(
-                #     "Date of Birth", format="DD/MM/YYYY", min_value=datetime(2000, 1, 1)
-                # ),
-                # "shirt_nr": st.column_config.NumberColumn("Shirt #", min_value=1, max_value=99),
-                # "position": st.column_config.SelectboxColumn("Position", options=POSITIONS),
-                # "preferred_foot": st.column_config.SelectboxColumn("Preferred Foot", options=["Left", "Right"])
+                # ⚠️ don't include "team" here since we dropped that column in df_view
             },
-            height=get_table_height(len(df)),
+            height=get_table_height(len(df_view)),
             num_rows="fixed",              # 🚫 prevent adding/removing rows
             use_container_width=True,
         )
-    except Exception as e:
-        st.error(f"Failed to render editor: {e}", icon=":material/error_outline")
-        return
 
-    if st.button("Save changes", type="primary", icon=":material/save:"):
-        # Safety checks before saving
-        try:
-            # Ensure player_id set is unchanged
-            edited_ids = set(pd.to_numeric(edited["player_id"], errors="coerce").astype("Int64").dropna().astype(int))
-            if edited_ids != original_ids:
-                st.error(
-                    "Player additions/removals are not allowed here. Please revert changes or perform roster updates directly in MongoDB.",
-                    icon=":material/error_outline"
+        submitted = st.form_submit_button(":material/save: Save changes", type="primary")
+
+        if submitted:
+            try:
+                # ---- Safety: no add/remove (same policy as before) ----
+                edited_ids = set(
+                    pd.to_numeric(edited_df["player_id"], errors="coerce")
+                    .astype("Int64").dropna().astype(int)
                 )
-                return
+                if edited_ids != original_ids:
+                    st.error(
+                        "Player additions/removals are not allowed here. "
+                        "Please revert or manage roster membership directly in MongoDB.",
+                        icon=":material/error_outline:",
+                    )
+                    st.stop()
 
-            # Basic per-row validation (optional: add stricter rules here)
-            if edited[["player_first_name", "player_last_name", "team"]].isnull().any().any():
-                st.error("Empty values detected. Please complete all required fields.", icon=":material/error_outline")
-                return
+                # ---- Safety: no duplicate IDs within this team ----
+                if edited_df["player_id"].duplicated(keep=False).any():
+                    dups = edited_df["player_id"][edited_df["player_id"].duplicated(keep=False)].tolist()
+                    st.error(f"Duplicate player_id(s) in the table: {sorted(set(dups))}", icon=":material/error_outline:")
+                    st.stop()
 
-            if mongo.save_roster_df(edited):
-                st.success("Roster updated.", icon=":material/check_box")
-            else:
-                st.error("Failed to save roster.", icon=":material/error_outline")
-        except DatabaseError as e:
-            st.error(str(e))
-        except Exception as e:
-            st.error(f"Validation or save failed: {e}", icon=":material/error_outline")
+                # ---- Row-level validation ----
+                req_cols = ["player_first_name", "player_last_name"]
+                missing_any = any(
+                    edited_df[c].isna().any() or (edited_df[c].astype(str).str.strip() == "").any()
+                    for c in req_cols if c in edited_df.columns
+                )
+                if missing_any:
+                    st.error("Empty values detected. Please complete all required name fields.", icon=":material/error_outline:")
+                    st.stop()
+
+                # ---- Reattach correct team & coerce types ----
+                to_save = edited_df.copy()
+                to_save["team"] = team
+                to_save["player_id"] = pd.to_numeric(to_save["player_id"], errors="coerce").astype("Int64")
+                if to_save["player_id"].isna().any():
+                    st.error("One or more player_id values are invalid.", icon=":material/error_outline:")
+                    st.stop()
+
+                # ---- Team-scoped replace ----
+                ok = mongo.save_roster_df(to_save, team=team)   # keyword arg avoids ordering issues
+                if ok:
+                    st.success(f"Roster for {team} updated.", icon=":material/check_box:")
+                else:
+                    st.error("Failed to save roster.", icon=":material/error_outline:")
+
+            except DatabaseError as e:
+                st.error(str(e))
+            except Exception as e:
+                st.error(f"Validation or save failed: {e}", icon=":material/error_outline:")

--- a/views/roster_management.py
+++ b/views/roster_management.py
@@ -140,11 +140,11 @@ def render(mongo: Any, user: Optional[dict[str, Any]]) -> None:
                     st.stop()
 
                 # ---- Team-scoped replace ----
-                ok = mongo.save_roster_df(to_save, team=team)   # keyword arg avoids ordering issues
+                ok = mongo.save_roster_df(to_save, team=team)
                 if ok:
                     st.success(f"Roster for {team} updated.", icon=":material/check_box:")
                 else:
-                    st.error("Failed to save roster.", icon=":material/error_outline:")
+                    st.error("Failed to save roster.", icon=":material/error_outlin:")
 
             except DatabaseError as e:
                 st.error(str(e))

--- a/views/rpe_dashboard.py
+++ b/views/rpe_dashboard.py
@@ -52,7 +52,7 @@ def render(mongo, user):
                 st.info("No RPE data available.")
             else:
                 pivot_df = acr_df.pivot(index="player_name", columns="week", values="acr")
-                display_df = pivot_df.applymap(format_acr_with_risk)
+                display_df = pivot_df.map(format_acr_with_risk)
 
                 st.dataframe(display_df, use_container_width=True, height=get_table_height(len(display_df)))
 

--- a/views/session_dashboard.py
+++ b/views/session_dashboard.py
@@ -58,7 +58,7 @@ def render(mongo, user):
         return
 
     # ---- Charts: Boxplot (new) --------------------------------------------
-    st.subheader(":material/stacked_bar_chart: RPE Distribution per Session")
+    #st.subheader(":material/stacked_bar_chart: RPE Distribution per Session")
     if rpe_df.empty:
         st.info("No per-session RPE data for the selected filters.")
     else:
@@ -68,7 +68,7 @@ def render(mongo, user):
         )
 
     # ---- Charts: your existing KPIs ---------------------------------------
-    st.subheader(":material/bar_chart: Average Load per Session Type")
+    #st.subheader(":material/bar_chart: Average Load per Session Type")
     if agg_df.empty:
         st.info("No aggregate data found.")
         return
@@ -78,13 +78,13 @@ def render(mongo, user):
         use_container_width=True
     )
 
-    st.subheader(":material/stacked_bar_chart: Load Distribution by Session Type (per Week)")
+    #st.subheader(":material/stacked_bar_chart: Load Distribution by Session Type (per Week)")
     st.plotly_chart(
         stacked_load_per_week(agg_df, title="Load Distribution by Session Type (per Week)"),
         use_container_width=True
     )
 
-    st.subheader(":material/percent: Relative Load Distribution by Session Type per Week (100% Stacked)")
+    #st.subheader(":material/percent: Relative Load Distribution by Session Type per Week (100% Stacked)")
     st.plotly_chart(
         stacked_pct_load_per_week(agg_df, title="Relative Load Distribution by Session Type per Week (100% Stacked)"),
         use_container_width=True

--- a/views/session_dashboard.py
+++ b/views/session_dashboard.py
@@ -1,8 +1,34 @@
 import streamlit as st
 import pandas as pd
-import plotly.express as px
+from datetime import date
+
 from utils.team_selector import team_selector
 from utils.constants import TEAMS
+
+from db.repositories.session_dashboard_repo import (
+    get_session_rpe_aggregates_df,
+    get_rpe_joined_per_session_df,
+    DatabaseError,
+)
+from charts.session_dashboard_graphs import (
+    rpe_boxplot_per_session,
+    rpe_outliers_table,
+    bar_avg_load_per_type,
+    stacked_load_per_week,
+    stacked_pct_load_per_week,
+)
+
+
+# ✅ Underscore the unhashable argument here
+@st.cache_data(show_spinner=False)
+def _load_aggregates(_mongo, team: str) -> pd.DataFrame:
+    return get_session_rpe_aggregates_df(_mongo, team)
+
+
+@st.cache_data(show_spinner=False)
+def _load_rpe_per_session(_mongo, team: str, use_range: bool, dt_from: date | None, dt_to: date | None) -> pd.DataFrame:
+    return get_rpe_joined_per_session_df(_mongo, team, dt_from if use_range else None, dt_to if use_range else None)
+
 
 def render(mongo, user):
     st.title(":material/timer: Session RPE Dashboard")
@@ -12,57 +38,69 @@ def render(mongo, user):
         st.info("Select a team to continue.", icon=":material/info:")
         return
 
+    c1, c2, c3 = st.columns([1, 1, 1])
+    with c1:
+        use_range = st.toggle("Filter by date range", value=False)
+    with c2:
+        dt_from = st.date_input("From", value=date.today(), disabled=not use_range)
+    with c3:
+        dt_to = st.date_input("To", value=date.today(), disabled=not use_range)
+
     try:
-        data = mongo.get_session_rpe_aggregates(team=team)
-        if not data:
-            st.info("No RPE data found.")
-            return
+        # ✅ You still call with `mongo` here
+        agg_df = _load_aggregates(mongo, team)
+        rpe_df = _load_rpe_per_session(mongo, team, use_range, dt_from, dt_to)
+    except DatabaseError as e:
+        st.error(str(e), icon=":material/error:")
+        return
+    except Exception as e:
+        st.error(f"Unexpected error: {e}", icon=":material/error:")
+        return
 
-        df = pd.DataFrame(data)
-        df["avg_load_per_session"] = df["total_load"] / df["session_count"]
-        df["avg_load_per_player"] = df["total_load"] / df["player_count"]
-        
-        # # Line graph: Total vs Average Player Load per Week
-        # weekly_df = df.groupby("week")[["total_load", "avg_load_per_player"]].sum().reset_index()
-        # fig1 = px.line(weekly_df, x="week", y=["total_load", "avg_load_per_player"],
-        #                markers=True, title="Weekly Load: Total vs Avg Player")
-        # st.plotly_chart(fig1, use_container_width=True)
-
-        # Bar graph: Avg Load per Session Type
-        type_df = df.groupby("session_type")["avg_load_per_session"].mean().reset_index()
-        fig2 = px.bar(type_df, x="session_type", y="avg_load_per_session",
-                      title="Average Load per Session Type", color="session_type")
-        st.plotly_chart(fig2, use_container_width=True)
-
-        # Stacked bar: Load per Session Type per Week
-        stacked_df = df.pivot(index="week", columns="session_type", values="total_load").fillna(0).reset_index()
-        fig3 = px.bar(stacked_df, x="week", y=stacked_df.columns[1:], title="Load Distribution by Session Type (per Week)", 
-                      labels={"value": "Load", "week": "Week"}, barmode="stack")
-        st.plotly_chart(fig3, use_container_width=True)
-
-        # Normalize session type loads as % of weekly total
-        stacked_df = df.pivot(index="week", columns="session_type", values="total_load").fillna(0)
-        stacked_df["total"] = stacked_df.sum(axis=1)
-        stacked_pct_df = stacked_df.div(stacked_df["total"], axis=0).drop(columns="total") * 100
-        stacked_pct_df = stacked_pct_df.reset_index().round(1)
-
-        # Melt for plotting
-        melted_pct = stacked_pct_df.melt(id_vars="week", var_name="Session Type", value_name="Percentage")
-
-        fig = px.bar(
-            melted_pct,
-            x="week",
-            y="Percentage",
-            color="Session Type",
-            text="Percentage",
-            title="Relative Load Distribution by Session Type per Week (100% Stacked)",
-            labels={"week": "Training Week"}
+    # ---- Charts: Boxplot (new) --------------------------------------------
+    st.subheader(":material/stacked_bar_chart: RPE Distribution per Session")
+    if rpe_df.empty:
+        st.info("No per-session RPE data for the selected filters.")
+    else:
+        st.plotly_chart(
+            rpe_boxplot_per_session(rpe_df, title=f"RPE Distribution per Session ({team})"),
+            use_container_width=True
         )
 
-        fig.update_traces(texttemplate="%{text}%", textposition="inside")
-        fig.update_layout(barmode="stack", yaxis_title="Percentage (%)")
+    # ---- Charts: your existing KPIs ---------------------------------------
+    st.subheader(":material/bar_chart: Average Load per Session Type")
+    if agg_df.empty:
+        st.info("No aggregate data found.")
+        return
 
-        st.plotly_chart(fig, use_container_width=True)
+    st.plotly_chart(
+        bar_avg_load_per_type(agg_df, title="Average Load per Session Type"),
+        use_container_width=True
+    )
 
-    except Exception as e:
-        st.error(f"Error loading session RPE data: {e}", icon=":material/error:")
+    st.subheader(":material/stacked_bar_chart: Load Distribution by Session Type (per Week)")
+    st.plotly_chart(
+        stacked_load_per_week(agg_df, title="Load Distribution by Session Type (per Week)"),
+        use_container_width=True
+    )
+
+    st.subheader(":material/percent: Relative Load Distribution by Session Type per Week (100% Stacked)")
+    st.plotly_chart(
+        stacked_pct_load_per_week(agg_df, title="Relative Load Distribution by Session Type per Week (100% Stacked)"),
+        use_container_width=True
+    )
+
+    # ---- Outliers table ----------------------------------------------------
+    st.subheader(":material/flag: RPE Outliers per Session (IQR × 1.5)")
+    if rpe_df.empty:
+        st.info("No outliers to display.")
+    else:
+        out = rpe_outliers_table(rpe_df, iqr_k=1.5)
+        if out.empty:
+            st.success("No outliers detected.")
+        else:
+            st.dataframe(
+                out.sort_values(["date", "session_type", "session_id", "player_id"]),
+                use_container_width=True,
+                height=400
+            )

--- a/views/wellness_dashboard.py
+++ b/views/wellness_dashboard.py
@@ -29,11 +29,16 @@ def render(mongo, user):
                 wellness_entries = mongo.get_today_wellness_entries(team)
 
                 # Get roster (only for display mapping)
-                roster = mongo.get_roster_players(team=team)
-                player_map = {
-                    int(p["player_id"]): f"{p['player_last_name']}, {p['player_first_name']}"
-                    for p in roster
-                }
+
+                # Get roster (for display mapping) — use standardized display_name
+                roster = mongo.get_player_names(team=team, style="LAST_FIRST", include_inactive=True)
+                player_map = {int(p["player_id"]): p["display_name"] for p in roster}
+
+                # roster = mongo.get_roster_players(team=team)
+                # player_map = {
+                #     int(p["player_id"]): f"{p['player_last_name']}, {p['player_first_name']}"
+                #     for p in roster
+                # }
 
                 # Build DataFrame
                 rows = []


### PR DESCRIPTION
	•	Created repository modules:
	•	roster_repo.py
	•	sessions_repo.py
	•	pdp_repo.py
	•	player_pdp_repo.py
	•	injury_repo.py
	•	wellness_repo.py
	•	rpe_repo.py
	•	attendance_repo.py
	•	Updated mongo_wrapper.py:
	•	Contains only pass-through methods.
	•	Each repo instantiated once in __init__.
	•	All database calls now routed through these repositories.
	•	Cleaned up any remaining direct calls to mongo.db[...].
	•	Verified that each function signature and return type remains compatible with the UI pages.
	•	Added keyword-only parameters to avoid ordering issues (def func(self, *, team: str, df: pd.DataFrame)).
	•	Updated mkdocs and imports to reflect new structure.